### PR TITLE
Make homepage the spotlight body field optional

### DIFF
--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -76,7 +76,7 @@ collections:
             fields:
               - {label: "Title", name: "title", widget: "string"}
               - {label: "Side Label", name: "label", widget: "string"}
-              - {label: "Body", name: "body", widget: "markdown"}
+              - {label: "Body", name: "body", widget: "markdown", required: "false"}
               - label: "Button Link"
                 name: "button"
                 widget: "object"
@@ -91,7 +91,7 @@ collections:
             fields:
               - {label: "Title", name: "title", widget: "string"}
               - {label: "Side Label", name: "label", widget: "string"}
-              - {label: "Body", name: "body", widget: "markdown"}
+              - {label: "Body", name: "body", widget: "markdown", required: "false"}
               - label: "Button Link"
                 name: "button"
                 widget: "object"


### PR DESCRIPTION
I realized we have some spotlights on the homepage that don't have a `body`, but it's required by the CMS! :grimacing: 