### PR TITLE
Titular SEO: Add titles (and occasionally descriptions) throughout

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,7 +1,9 @@
 module.exports = {
   siteMetadata: {
-    title: 'tBTC — Bitcoin on Ethereum',
-    description: '1. Deposit BTC. 2. Mint TBTC. 3. Lend and earn interest on your BTC.'
+    title: "Bitcoin on Ethereum",
+    titleTemplate: "tBTC – %s",
+    description: "1. Deposit BTC. 2. Mint TBTC. 3. Lend and earn interest on your BTC.",
+    url: "https://tbtc.network",
   },
   plugins: [
     'gatsby-plugin-react-helmet',

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -1,16 +1,17 @@
 import React from 'react'
 import { Link } from 'gatsby'
 import { Announcement, Footer, Header, Newsletter } from './lib'
+import SEO from './SEO.js'
 
 import '../css/app.scss'
 
-
 export default (props) => {
-  const { children } = props
+  const { children, title, description } = props
 
   return (
     <div className="main">
       <Header />
+      <SEO title={title} description={description} />
       <Announcement>
         <Link to="/news/2020-02-14-ropsten">tBTC is now live on Ropsten</Link>. Mainnet launch is coming soon.
       </Announcement>

--- a/src/components/SEO.js
+++ b/src/components/SEO.js
@@ -1,0 +1,81 @@
+import React from "react"
+import { Helmet } from "react-helmet"
+import PropTypes from "prop-types"
+import { StaticQuery, graphql } from "gatsby"
+
+const SEO = ({ title, description, image, pathname, article }) => (
+  <StaticQuery
+    query={query}
+    render={({
+      site: {
+        siteMetadata: {
+          defaultTitle,
+          titleTemplate,
+          defaultDescription,
+          siteUrl,
+          defaultImage,
+          twitterUsername,
+        },
+      },
+    }) => {
+      const seo = {
+        title: title || defaultTitle,
+        description: description || defaultDescription,
+        image: `${siteUrl}${image || defaultImage}`,
+        url: `${siteUrl}${pathname || "/"}`,
+      }
+      return (
+        <>
+          <Helmet title={seo.title} titleTemplate={titleTemplate}>
+            <meta name="description" content={seo.description} />
+            {seo.url && <meta property="og:url" content={seo.url} />}
+            {(article ? true : null) && (
+              <meta property="og:type" content="article" />
+            )}
+            {seo.title && <meta property="og:title" content={seo.title} />}
+            {seo.description && (
+              <meta property="og:description" content={seo.description} />
+            )}
+            {seo.image && <meta property="og:image" content={seo.image} />}
+            <meta name="twitter:card" content="summary_large_image" />
+            {twitterUsername && (
+              <meta name="twitter:creator" content={twitterUsername} />
+            )}
+            {seo.title && <meta name="twitter:title" content={seo.title} />}
+            {seo.description && (
+              <meta name="twitter:description" content={seo.description} />
+            )}
+            {seo.image && <meta name="twitter:image" content={seo.image} />}
+          </Helmet>
+        </>
+      )
+    }}
+  />
+)
+export default SEO
+SEO.propTypes = {
+  title: PropTypes.string,
+  description: PropTypes.string,
+  image: PropTypes.string,
+  pathname: PropTypes.string,
+  article: PropTypes.bool,
+}
+SEO.defaultProps = {
+  title: null,
+  description: null,
+  image: null,
+  pathname: null,
+  article: false,
+}
+const query = graphql`
+  query SEO {
+    site {
+      siteMetadata {
+        defaultTitle: title
+        titleTemplate
+        defaultDescription: description
+        siteUrl: url
+      }
+    }
+  }
+`

--- a/src/components/lib/Footer.js
+++ b/src/components/lib/Footer.js
@@ -33,7 +33,7 @@ const Footer = () => (
             </Link>
           </li>
           <li>
-            <a href="http://dapp.test.tbtc.network/" target="_blank" rel="noopener noreferrer">
+            <a href="https://dapp.test.tbtc.network/" target="_blank" rel="noopener noreferrer">
               dAPP
             </a>
           </li>

--- a/src/components/lib/Header.js
+++ b/src/components/lib/Header.js
@@ -13,9 +13,9 @@ const Header = props => {
   return (
     <header className="header">
       <nav className="nav">
-        <a className="logo" href="/">
+        <Link className="logo" to="/">
           <TBTCLogo width="165" />
-        </a>
+        </Link>
 
         <div className={classNames('menu', { 'open': showMenu })}>
           <button className={classNames('menu-label', { 'open': showMenu })}

--- a/src/components/lib/Header.js
+++ b/src/components/lib/Header.js
@@ -29,7 +29,7 @@ const Header = props => {
             <li><Link to="/faq">FAQ</Link></li>
           </ul>
           <ul className="nav-right">
-            <li><a className="mint-button" href="http://dapp.test.tbtc.network/" target="_blank" rel="noopener noreferrer">Mint tBTC</a></li>
+            <li><a className="mint-button" href="https://dapp.test.tbtc.network/" target="_blank" rel="noopener noreferrer">Mint tBTC</a></li>
             <li><a className="site-repo-link" href="https://github.com/keep-network/tbtc-website" target="_blank" rel="noopener noreferrer">Repository</a></li>
           </ul>
         </div>

--- a/src/pages/developers/how-to-integrate-tbtc-into-your-defi-dapp.md
+++ b/src/pages/developers/how-to-integrate-tbtc-into-your-defi-dapp.md
@@ -14,7 +14,7 @@ Developers will need to be familiar with Solidity and with ERC-20 tokens general
 
 The following resources contain the tools needed to integrate TBTC, as well as a brief guide:
 
-- [The Ropsten-connected tBTC dapp](https://github.com/keep-network/tbtc-dapp) (use the [tBTC dapp on testnet](http://dapp.test.tbtc.network/) here)
+- [The Ropsten-connected tBTC dapp](https://github.com/keep-network/tbtc-dapp) (use the [tBTC dapp on testnet](https://dapp.test.tbtc.network/) here)
 - [tBTC smart contracts](https://github.com/keep-network/tbtc)
 - [tbtc.js](https://github.com/keep-network/tbtc.js)
 - [The technical specification](http://docs.keep.network/tbtc/)

--- a/src/pages/developers/how-to-use-the-tbtc-dapp.md
+++ b/src/pages/developers/how-to-use-the-tbtc-dapp.md
@@ -16,7 +16,7 @@ To start, you need to:
 * Get some ETH from [Coinbase](http://coinbase.com) or another source (to pay for gas) if you don&#39;t have any already.
 * Make sure you have some ETH in your Metamask wallet.
 
-Once the ETH is in your wallet, go to [the Ropsten tBTC dApp](http://dapp.test.tbtc.network).
+Once the ETH is in your wallet, go to [the Ropsten tBTC dApp](https://dapp.test.tbtc.network).
 
 Next there are 5 steps:
 

--- a/src/pages/developers/index.md
+++ b/src/pages/developers/index.md
@@ -6,7 +6,7 @@ title: Build with tBTC
 Developers can build on tBTC. There are several resources to help devs use tBTC infrastructure to bring Bitcoin to Ethereum. Get started with the following resources:
 
 - [How to Integrate TBTC into Your Defi Dapp](/developers/how-to-integrate-tbtc-into-your-defi-dapp)
-- The Ropsten-connected [tBTC dApp](http://dapp.test.tbtc.network/)
+- The Ropsten-connected [tBTC dApp](https://dapp.test.tbtc.network/)
 - [tBTC smart contracts](https://github.com/keep-network/tbtc)
 - [tbtc.js](https://github.com/keep-network/tbtc.js)
 - [The technical specification](http://docs.keep.network/tbtc/)

--- a/src/pages/news/2020-02-14-ropsten.md
+++ b/src/pages/news/2020-02-14-ropsten.md
@@ -8,16 +8,16 @@ tBTC is Open-Source and Live on Ropsten
 
 The first release of tBTC is now live on Ropsten, the public Ethereum testnet.
 
-To try minting your first TBTC, visit the [reference dApp](http://dapp.test.tbtc.network). Make sure you're loaded up on testnet bitcoin and Ropsten ether, and you can be the first TBTC whale
+To try minting your first TBTC, visit the [reference dApp](https://dapp.test.tbtc.network). Make sure you're loaded up on testnet bitcoin and Ropsten ether, and you can be the first TBTC whale
 :sunglasses_emoji:
 
 While the code undergoes audit and further testing, development is now [public on GitHub](https://github.com/keep-network/tbtc).  That means you can begin building Bitcoin experiences on DeFi apps like Compound and Uniswap,
 today. To learn more about this release, you can:
 
-\-> [Read the latest spec](http://docs.keep.network/tbtc/index.pdf)
+\-> [Read the latest spec](https://docs.keep.network/tbtc/index.pdf)
 
 \-> [Browse the source code](https://github.com/keep-network/tbtc/tree/master/solidity)
 
-\-> [Play with the dApp](http://dapp.test.tbtc.network/)
+\-> [Play with the dApp](https://dapp.test.tbtc.network/)
 
 \-> [Build on testnet](https://www.npmjs.com/package/@keep-network/tbtc.js)

--- a/src/pages/news/index.js
+++ b/src/pages/news/index.js
@@ -7,7 +7,7 @@ import { App } from './../../components'
 const News = ({ data }) => {
   const { edges: newsItems } = data.allMarkdownRemark
   return (
-    <App>
+    <App title="News">
       <div className="news">
         <div className="container">
           <div className="row justify-content-center no-gutters">

--- a/src/templates/about-page.js
+++ b/src/templates/about-page.js
@@ -34,7 +34,7 @@ const AboutPage = ({ data }) => {
   const { markdownRemark: post } = data
 
   return (
-    <App>
+    <App title={post.frontmatter.title}>
       <AboutPageTemplate
         title={post.frontmatter.title}
         body={post.html}

--- a/src/templates/about-page.js
+++ b/src/templates/about-page.js
@@ -13,7 +13,7 @@ export const AboutPageTemplate = ({ title, body, supporters }) => (
           <header>
             <h1>{title}</h1>
             <div className="body" dangerouslySetInnerHTML={{ __html: body }} />
-            <a href="http://dapp.test.tbtc.network/" target="_blank" rel="noopener noreferrer">Mint tBTC</a>
+            <a href="https://dapp.test.tbtc.network/" target="_blank" rel="noopener noreferrer">Mint tBTC</a>
           </header>
           <div className="supporters">
             {supporters && supporters.map((supporter, i) => (

--- a/src/templates/developers-page.js
+++ b/src/templates/developers-page.js
@@ -35,7 +35,7 @@ const DevelopersPage = ({ data }) => {
   const { edges: resources } = data.allMarkdownRemark
 
   return (
-    <App>
+    <App title={post.frontmatter.title}>
       <DevelopersPageTemplate
         title={post.frontmatter.title}
         body={post.html}

--- a/src/templates/faq-page.js
+++ b/src/templates/faq-page.js
@@ -50,7 +50,7 @@ const FaqPage = ({ data }) => {
   const { markdownRemark: post } = data
 
   return (
-    <App>
+    <App title={post.frontmatter.title}>
       <FaqPageTemplate
         title={post.frontmatter.title}
         questions={post.frontmatter.questions} />

--- a/src/templates/news-item.js
+++ b/src/templates/news-item.js
@@ -18,7 +18,8 @@ export const NewsItemTemplate = ({ title, date, body }) => (
 const NewsItem = ({ data }) => {
   const { markdownRemark: post } = data
 
-  return <App>
+  return <App title={post.frontmatter.title}
+              description={post.frontmatter.description}>
     <NewsItemTemplate
       date={post.frontmatter.date}
       description={post.frontmatter.description}

--- a/src/templates/resource.js
+++ b/src/templates/resource.js
@@ -20,7 +20,7 @@ const Resource = ({ data }) => {
   const title = post.frontmatter.heading ?
     post.frontmatter.heading : post.frontmatter.title
 
-  return <App>
+  return <App title={title}>
     <ResourceTemplate
       body={post.html}
       title={title}


### PR DESCRIPTION
This was driving me bananabonkers. Pulled most of it from
https://www.gatsbyjs.org/docs/add-seo-component/, then
stripped it down (for now) and added titles to most pages and
descriptions to news item pages.

EDIT: I threw in two bonuses: links to the dApp now correctly point
to https, and the header logo link works in preview renderings.

Closes #5.