### PR TITLE
Fix missing news items

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -17,7 +17,6 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
               slug
             }
             frontmatter {
-              path
               template
             }
           }
@@ -37,7 +36,7 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
     const templateName = node.frontmatter.template || `default`
     const template = path.resolve(path.join('src/templates/', `${templateName}.js`))
     createPage({
-      path: node.frontmatter.path || node.fields.slug,
+      path: node.fields.slug,
       component: template,
       context: { id: node.id }, // additional data can be passed via context
     })

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -13,14 +13,12 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
         edges {
           node {
             id
+            fields {
+              slug
+            }
             frontmatter {
               path
               template
-            }
-            parent {
-              ... on File {
-                relativePath
-              }
             }
           }
         }
@@ -39,7 +37,7 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
     const templateName = node.frontmatter.template || `default`
     const template = path.resolve(path.join('src/templates/', `${templateName}.js`))
     createPage({
-      path: node.frontmatter.path || node.parent.relativePath.replace(/.md$/,''),
+      path: node.frontmatter.path || node.fields.slug,
       component: template,
       context: { id: node.id }, // additional data can be passed via context
     })

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,4 +1,5 @@
 const path = require(`path`)
+const { createFilePath } = require('gatsby-source-filesystem')
 
 exports.createPages = async ({ actions, graphql, reporter }) => {
   const { createPage } = actions
@@ -43,4 +44,17 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
       context: { id: node.id }, // additional data can be passed via context
     })
   })
+}
+
+exports.onCreateNode = ({ node, actions, getNode }) => {
+  const { createNodeField } = actions
+
+  if (node.internal.type === `MarkdownRemark`) {
+    const value = createFilePath({ node, getNode })
+    createNodeField({
+      name: `slug`,
+      node,
+      value,
+    })
+  }
 }

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -1,5 +1,4 @@
 import React from 'react'
-import { Link } from 'gatsby'
 import { Announcement, Footer, Header, Newsletter } from './lib'
 import SEO from './SEO.js'
 
@@ -13,7 +12,7 @@ export default (props) => {
       <Header />
       <SEO title={title} description={description} />
       <Announcement>
-        tBTC will launch on April 27th, 2020. Read more in <a href="https://www.bloomberg.com/news/articles/2020-04-02/bitcoin-s-ethereum-rivalry-could-be-assuaged-with-tbtc-bridge" target="_blank" rel="noreferrer">Bloomberg</a>.
+        tBTC will launch on April 27th, 2020. Read more in <a href="https://www.bloomberg.com/news/articles/2020-04-02/bitcoin-s-ethereum-rivalry-could-be-assuaged-with-tbtc-bridge" target="_blank" rel="noopener noreferrer">Bloomberg</a>.
       </Announcement>
       <div className="app">
         { children }

--- a/src/components/lib/Resources.js
+++ b/src/components/lib/Resources.js
@@ -13,7 +13,7 @@ const Resources = ({ data }) => {
           <div className="resource-item" key={node.id}>
             <h2>{node.frontmatter.title}</h2>
             <p>{node.frontmatter.description}</p>
-            <Link to={`/${node.frontmatter.path}`}>go</Link>
+            <Link to={`/${node.fields.slug}`}>go</Link>
           </div>
       ))}
     </div>
@@ -34,15 +34,17 @@ export const query = graphql`
     allMarkdownRemark(
       limit: 3,
       sort: {order: ASC, fields: [frontmatter___date]},
-      filter: {frontmatter: {path: {ne: null}, template: {eq: "resource"}}}
+      filter: {frontmatter: {template: {eq: "resource"}}}
     ) {
       edges {
         node {
           id
+          fields {
+            slug
+          }
           frontmatter {
             title
             description
-            path
           }
         }
       }

--- a/src/pages/news/index.js
+++ b/src/pages/news/index.js
@@ -23,7 +23,7 @@ const News = ({ data }) => {
                       <h2>{node.frontmatter.title}</h2>
                       <p>{node.excerpt}</p>
                     </div>
-                    <Link to={`/${node.frontmatter.path}`}>Read</Link>
+                    <Link to={`/${node.fields.slug}`}>Read</Link>
                   </div>
                 </div>
               ))}
@@ -43,15 +43,17 @@ export const query = graphql`
   query LatestNews {
     allMarkdownRemark(
       sort: {order: DESC, fields: [frontmatter___date]},
-      filter: {frontmatter: {path: {ne: null}, template: {eq: "news-item"}}}
+      filter: {frontmatter: {template: {eq: "news-item"}}}
     ) {
       edges {
         node {
           id
           excerpt
+          fields {
+            slug
+          }
           frontmatter {
             title
-            path
           }
         }
       }

--- a/src/templates/developers-page.js
+++ b/src/templates/developers-page.js
@@ -17,7 +17,7 @@ export const DevelopersPageTemplate = ({ title, body, resources }) => (
             <li>Resources</li>
             { resources && resources.map(({ node }) => (
               <li key={node.id}>
-                <Link to={node.frontmatter.path}>
+                <Link to={node.fields.slug}>
                   {node.frontmatter.title}
                 </Link>
               </li>
@@ -71,9 +71,11 @@ export const pageQuery = graphql`
       edges {
         node {
           id
+          fields {
+            slug
+          }
           frontmatter {
             title
-            path
           }
         }
       }

--- a/src/templates/home-page.js
+++ b/src/templates/home-page.js
@@ -85,7 +85,7 @@ export const HomePageTemplate = (props) => {
               <div className="latest-news-item col-sm-12 col-md-4" key={node.id}>
                 <h2>{node.frontmatter.title}</h2>
                 <p>{node.excerpt}</p>
-                <Link to={`/${node.frontmatter.path}`}>Read more</Link>
+                <Link to={`/${node.fields.slug}`}>Read more</Link>
               </div>
             ))}
           </div>
@@ -185,15 +185,17 @@ export const query = graphql`
     allMarkdownRemark(
       limit: 3,
       sort: {order: DESC, fields: [frontmatter___date]},
-      filter: {frontmatter: {path: {ne: null}, template: {eq: "news-item"}}}
+      filter: {frontmatter: {template: {eq: "news-item"}}}
     ) {
       edges {
         node {
           id
           excerpt
+          fields {
+            slug
+          }
           frontmatter {
             title
-            path
           }
         }
       }


### PR DESCRIPTION
New news posts generated in by the admin interface are missing the `path` property. Makes the `slug` property visible to queries and updates news and resource queries to use `slug` property instead of `path`.