### PR TITLE
Enable announcement banner to be editable in the CMS

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -31,7 +31,11 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
     return
   }
 
-  result.data.allMarkdownRemark.edges.forEach(({ node }) => {
+  // Filter out the content that we don't want pages created for
+  const postOrPage = result.data.allMarkdownRemark.edges
+    .filter(edge => edge.node.frontmatter.template !== "announcement");
+
+  postOrPage.forEach(({ node }) => {
     debugger;
     const templateName = node.frontmatter.template || `default`
     const template = path.resolve(path.join('src/templates/', `${templateName}.js`))

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -11,9 +11,7 @@ export default (props) => {
     <div className="main">
       <Header />
       <SEO title={title} description={description} />
-      <Announcement>
-        tBTC will launch on April 27th, 2020. Read more in <a href="https://www.bloomberg.com/news/articles/2020-04-02/bitcoin-s-ethereum-rivalry-could-be-assuaged-with-tbtc-bridge" target="_blank" rel="noopener noreferrer">Bloomberg</a>.
-      </Announcement>
+      <Announcement />
       <div className="app">
         { children }
       </div>

--- a/src/components/lib/Announcement.js
+++ b/src/components/lib/Announcement.js
@@ -1,18 +1,44 @@
 import React from 'react'
+import { graphql, StaticQuery } from 'gatsby'
 
 
-const Announcement = ({ children }) => (
+const Announcement = ({ body }) => (
   <div className="announcement">
     <div className="container">
       <div className="row justify-content-center no-gutters">
         <div className="col-10 col-sm-12 col-md-12 col-lg-10 content">
-          <p>
-            { children }
-          </p>
+          <div className="body" dangerouslySetInnerHTML={{ __html: body }} />
         </div>
       </div>
     </div>
   </div>
 )
 
-export default Announcement
+
+// Query for announcement
+export const query = graphql`
+  query Announcement {
+    allMarkdownRemark(
+      filter: { frontmatter: { template: { eq: "announcement" } } }
+    ) {
+      edges {
+        node {
+          html
+        }
+      }
+    }
+  }
+`
+
+export default () => (
+  <StaticQuery
+    query={query}
+    render={data => {
+      const body = data.allMarkdownRemark.edges[0].node.html
+      if (!body) {
+        return null
+      }
+      return <Announcement body={body} />
+    }}
+  />
+)

--- a/src/css/announcement.scss
+++ b/src/css/announcement.scss
@@ -38,7 +38,7 @@
         }
 
         a {
-            text-decoration: underline;
+            @extend %external-arrow-link;
         }
     }
 

--- a/src/css/typography.scss
+++ b/src/css/typography.scss
@@ -67,6 +67,12 @@ a {
     }
 }
 
+%external-arrow-link {
+    &[href^=http]:after {
+        content: ' ↗';
+    }
+}
+
 .section-title {
     @extend .h1;
     border-top: 1px solid $black;

--- a/src/pages/announcement/index.md
+++ b/src/pages/announcement/index.md
@@ -1,0 +1,5 @@
+---
+template: 'announcement'
+title: tBTC Stakedrop
+---
+The first stakedrop for tBTC is on June 8, 2020. [Add to Calendar](#)

--- a/src/pages/announcement/index.md
+++ b/src/pages/announcement/index.md
@@ -1,5 +1,5 @@
 ---
 template: 'announcement'
-title: tBTC Stakedrop
+title: Launch Announcement
 ---
-The first stakedrop for tBTC is on June 8, 2020. [Add to Calendar](#)
+tBTC will launch on April 27th, 2020. Read more in <a href="https://www.bloomberg.com/news/articles/2020-04-02/bitcoin-s-ethereum-rivalry-could-be-assuaged-with-tbtc-bridge" target="_blank" rel="noopener noreferrer">Bloomberg</a>.

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -141,3 +141,14 @@ collections:
               {label: "Question", name: "question", widget: "string"},
               {label: "Answer", name: "answer", widget: "markdown"}
             ]
+
+  - name: "header_and_footer"
+    label: "Header & Footer"
+    files:
+      - file: "src/pages/announcement/index.md"
+        label: "Announcement Banner"
+        name: "announcement"
+        fields:
+          - {label: "Template Key", name: "template", widget: "hidden", default: "announcement"}
+          - {label: "Title", name: "title", widget: "string", required: false}
+          - {label: "Body", name: "body", widget: "markdown", required: false, minimal: true}


### PR DESCRIPTION
Allow the banner copy to be edited via the CMS admin. Announcement banner will only appear if the body content is not empty.
