### PR TITLE
Enable standalone pages to be editable for each locale

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 src/app.less/
+static/admin/config.yml
 *.code-workspace
 build/
 .DS_Store

--- a/src/cms/config/base-config.yml
+++ b/src/cms/config/base-config.yml
@@ -138,6 +138,13 @@ collections:
                     }
                   ],
               }
+      - file: "src/pages/news/index.md"
+        label: "News"
+        name: "news"
+        fields:
+          - {label: "Template Key", name: "template", widget: "hidden", default: "news-page"}
+          - {label: "Path", name: "path", widget: "hidden", default: "/news"}
+          - {label: "Title", name: "title", widget: "string"}
       - file: "src/pages/about/index.md"
         label: "About"
         name: "about"

--- a/src/cms/config/index.js
+++ b/src/cms/config/index.js
@@ -7,10 +7,16 @@ const config = require('../../../gatsby-config.js')
 const { defaultLocale, supportedLocales } = config.siteMetadata
 const nonDefaultLocales = supportedLocales.filter(l=>l !== defaultLocale)
 
-function generateConfig() {
+function parseBaseConfig() {
   const configPath = path.join(__dirname, './base-config.yml')
   const contents = fs.readFileSync(configPath, 'utf8')
-  const base = YAML.parse(contents)
+  return YAML.parse(contents)
+}
+
+exports.parseBaseConfig = parseBaseConfig
+
+function generateConfig() {
+  const base = parseBaseConfig()
 
   let newCollections = []
 

--- a/src/pages/about/index.de.md
+++ b/src/pages/about/index.de.md
@@ -1,0 +1,16 @@
+---
+template: 'about-page'
+path: /about
+title: About tBTC
+supporters:
+  - name: Keep
+    description: Keep is a privacy layer for Ethereum. A “keep” is an off-chain container for private data. Keeps help contracts harness the full power of the public blockchain — enabling deep interactivity with private data. The Keep network, powered by KEEP tokens, handles custodianship for tBTC.
+    url: https://keep.network/
+  - name: Summa
+    description: Summa provides custom-built interoperability solutions for companies throughout the blockchain ecosystem. Its solutions allow companies to access larger markets, expand their feature-sets, and access new liquidity in a unified cross-chain marketplace.
+    url: https://summa.one/
+  - name: Cross-Chain Group
+    description: The Cross-Chain Group is an industry resource and working group dedicated to furthering the research, design, and implementation of cross-chain architecture. Through educational events, advisory services, and open-source tooling, its goal is to expand blockchain interoperability and foster an environment that is more connected, functional, and scalable.
+    url: https://www.crosschain.group/
+---
+tBTC is a fully Bitcoin-backed ERC-20 token pegged to the price of Bitcoin. It facilitates Bitcoin holders to act on the Ethereum blockchain and access the decentralized finance (DeFi) ecosystem. tBTC is an open-source project supported by groups including [Keep](https://keep.network/), [Summa](https://summa.one/) and the [Cross-Chain Group](https://www.crosschain.group/).

--- a/src/pages/about/index.es.md
+++ b/src/pages/about/index.es.md
@@ -1,0 +1,16 @@
+---
+template: 'about-page'
+path: /about
+title: About tBTC
+supporters:
+  - name: Keep
+    description: Keep is a privacy layer for Ethereum. A “keep” is an off-chain container for private data. Keeps help contracts harness the full power of the public blockchain — enabling deep interactivity with private data. The Keep network, powered by KEEP tokens, handles custodianship for tBTC.
+    url: https://keep.network/
+  - name: Summa
+    description: Summa provides custom-built interoperability solutions for companies throughout the blockchain ecosystem. Its solutions allow companies to access larger markets, expand their feature-sets, and access new liquidity in a unified cross-chain marketplace.
+    url: https://summa.one/
+  - name: Cross-Chain Group
+    description: The Cross-Chain Group is an industry resource and working group dedicated to furthering the research, design, and implementation of cross-chain architecture. Through educational events, advisory services, and open-source tooling, its goal is to expand blockchain interoperability and foster an environment that is more connected, functional, and scalable.
+    url: https://www.crosschain.group/
+---
+tBTC is a fully Bitcoin-backed ERC-20 token pegged to the price of Bitcoin. It facilitates Bitcoin holders to act on the Ethereum blockchain and access the decentralized finance (DeFi) ecosystem. tBTC is an open-source project supported by groups including [Keep](https://keep.network/), [Summa](https://summa.one/) and the [Cross-Chain Group](https://www.crosschain.group/).

--- a/src/pages/about/index.fr.md
+++ b/src/pages/about/index.fr.md
@@ -1,0 +1,16 @@
+---
+template: 'about-page'
+path: /about
+title: About tBTC
+supporters:
+  - name: Keep
+    description: Keep is a privacy layer for Ethereum. A “keep” is an off-chain container for private data. Keeps help contracts harness the full power of the public blockchain — enabling deep interactivity with private data. The Keep network, powered by KEEP tokens, handles custodianship for tBTC.
+    url: https://keep.network/
+  - name: Summa
+    description: Summa provides custom-built interoperability solutions for companies throughout the blockchain ecosystem. Its solutions allow companies to access larger markets, expand their feature-sets, and access new liquidity in a unified cross-chain marketplace.
+    url: https://summa.one/
+  - name: Cross-Chain Group
+    description: The Cross-Chain Group is an industry resource and working group dedicated to furthering the research, design, and implementation of cross-chain architecture. Through educational events, advisory services, and open-source tooling, its goal is to expand blockchain interoperability and foster an environment that is more connected, functional, and scalable.
+    url: https://www.crosschain.group/
+---
+tBTC is a fully Bitcoin-backed ERC-20 token pegged to the price of Bitcoin. It facilitates Bitcoin holders to act on the Ethereum blockchain and access the decentralized finance (DeFi) ecosystem. tBTC is an open-source project supported by groups including [Keep](https://keep.network/), [Summa](https://summa.one/) and the [Cross-Chain Group](https://www.crosschain.group/).

--- a/src/pages/about/index.pl.md
+++ b/src/pages/about/index.pl.md
@@ -1,0 +1,16 @@
+---
+template: 'about-page'
+path: /about
+title: About tBTC
+supporters:
+  - name: Keep
+    description: Keep is a privacy layer for Ethereum. A “keep” is an off-chain container for private data. Keeps help contracts harness the full power of the public blockchain — enabling deep interactivity with private data. The Keep network, powered by KEEP tokens, handles custodianship for tBTC.
+    url: https://keep.network/
+  - name: Summa
+    description: Summa provides custom-built interoperability solutions for companies throughout the blockchain ecosystem. Its solutions allow companies to access larger markets, expand their feature-sets, and access new liquidity in a unified cross-chain marketplace.
+    url: https://summa.one/
+  - name: Cross-Chain Group
+    description: The Cross-Chain Group is an industry resource and working group dedicated to furthering the research, design, and implementation of cross-chain architecture. Through educational events, advisory services, and open-source tooling, its goal is to expand blockchain interoperability and foster an environment that is more connected, functional, and scalable.
+    url: https://www.crosschain.group/
+---
+tBTC is a fully Bitcoin-backed ERC-20 token pegged to the price of Bitcoin. It facilitates Bitcoin holders to act on the Ethereum blockchain and access the decentralized finance (DeFi) ecosystem. tBTC is an open-source project supported by groups including [Keep](https://keep.network/), [Summa](https://summa.one/) and the [Cross-Chain Group](https://www.crosschain.group/).

--- a/src/pages/about/index.ru.md
+++ b/src/pages/about/index.ru.md
@@ -1,0 +1,16 @@
+---
+template: 'about-page'
+path: /about
+title: About tBTC
+supporters:
+  - name: Keep
+    description: Keep is a privacy layer for Ethereum. A “keep” is an off-chain container for private data. Keeps help contracts harness the full power of the public blockchain — enabling deep interactivity with private data. The Keep network, powered by KEEP tokens, handles custodianship for tBTC.
+    url: https://keep.network/
+  - name: Summa
+    description: Summa provides custom-built interoperability solutions for companies throughout the blockchain ecosystem. Its solutions allow companies to access larger markets, expand their feature-sets, and access new liquidity in a unified cross-chain marketplace.
+    url: https://summa.one/
+  - name: Cross-Chain Group
+    description: The Cross-Chain Group is an industry resource and working group dedicated to furthering the research, design, and implementation of cross-chain architecture. Through educational events, advisory services, and open-source tooling, its goal is to expand blockchain interoperability and foster an environment that is more connected, functional, and scalable.
+    url: https://www.crosschain.group/
+---
+tBTC is a fully Bitcoin-backed ERC-20 token pegged to the price of Bitcoin. It facilitates Bitcoin holders to act on the Ethereum blockchain and access the decentralized finance (DeFi) ecosystem. tBTC is an open-source project supported by groups including [Keep](https://keep.network/), [Summa](https://summa.one/) and the [Cross-Chain Group](https://www.crosschain.group/).

--- a/src/pages/california-privacy-notice/index.de.md
+++ b/src/pages/california-privacy-notice/index.de.md
@@ -1,0 +1,158 @@
+---
+template: 'legal-page'
+path: /california-privacy-notice
+title: KEEP SECZ Privacy Notice for California Residents
+---
+**Effective Date:** - April 16, 2020
+
+This **Privacy Notice for California Residents** supplements the information contained in KEEP SECZ&#39;s [Privacy Policy](/privacy-policy) and applies solely to all visitors, users, and others who reside in the State of California (&quot;consumers&quot; or &quot;you&quot;). We adopt this notice to comply with the California Consumer Privacy Act of 2018 (CCPA) and any terms defined in the CCPA have the same meaning when used in this notice.
+
+## Information We Collect
+
+Our Website may collect information that identifies, relates to, describes, references, is capable of being associated with, or could reasonably be linked, directly or indirectly, with a particular consumer or device (&quot; **personal information**&quot;). In particular, our Website collects the following categories of personal information from its consumers within the last twelve (12) months:
+
+| **Category** | **Examples** | **Collected** |
+| --- | --- | --- |
+| A. Identifiers. | Email address, Ethereum Wallet address | YES |
+| B. Personal information categories listed in the California Customer Records statute (Cal. Civ. Code § 1798.80(e)). | A name, signature, Social Security number, physical characteristics or description, address, telephone number, passport number, driver&#39;s license or state identification card number, insurance policy number, education, employment, employment history, account number, credit card number, debit card number, or any other financial information, medical information, or health insurance information.Some personal information included in this category may overlap with other categories. | YES |
+| C. Protected classification characteristics under California or federal law. | Age (40 years or older), race, color, ancestry, national origin, citizenship, religion or creed, marital status, medical condition, physical or mental disability, sex (including gender, gender identity, gender expression, pregnancy or childbirth and related medical conditions), sexual orientation, veteran or military status, genetic information (including familial genetic information).| NO |
+| D. Commercial information. | Records of personal property, products or services purchased, obtained, or considered, or other purchasing or consuming histories or tendencies. | NO |
+| E. Biometric information. | Genetic, physiological, behavioral, and biological characteristics, or activity patterns used to extract a template or other identifier or identifying information, such as, fingerprints, faceprints, and voiceprints, iris or retina scans, keystroke, gait, or other physical patterns, and sleep, health, or exercise data. | NO |
+| F. Internet or other similar network activity. | Browsing history, search history, information on a consumer&#39;s interaction with a website, application, or advertisement. | NO |
+| G. Geolocation data. | Physical location or movements. | NO |
+| H. Sensory data. | Audio, electronic, visual, thermal, olfactory, or similar information. | NO |
+| I. Professional or employment-related information. | Current or past job history or performance evaluations. | NO |
+| J. Non-public education information (per the Family Educational Rights and Privacy Act (20 U.S.C. Section 1232g, 34 C.F.R. Part 99)). | Education records directly related to a student maintained by an educational institution or party acting on its behalf, such as grades, transcripts, class lists, student schedules, student identification codes, student financial information, or student disciplinary records. | NO |
+| K. Inferences drawn from other personal information. | Profile reflecting a person&#39;s preferences, characteristics, psychological trends, predispositions, behavior, attitudes, intelligence, abilities, and aptitudes. | NO |
+
+Personal information does not include:
+
+- Publicly available information from government records.
+- Deidentified or aggregated consumer information.
+- Information excluded from the CCPA&#39;s scope, like:
+  - health or medical information covered by the Health Insurance Portability and Accountability Act of 1996 (HIPAA) and the California Confidentiality of Medical Information Act (CMIA) or clinical trial data;
+  - personal information covered by certain sector-specific privacy laws, including the Fair Credit Reporting Act (FRCA), the Gramm-Leach-Bliley Act (GLBA) or California Financial Information Privacy Act (FIPA), and the Driver&#39;s Privacy Protection Act of 1994.
+
+KEEP SECZ obtains the categories of personal information listed above from the following categories of sources:
+
+- Directly from you. For example, from forms you complete or products you use.
+
+## Use of Personal Information
+
+We may use or disclose the personal information we collect for one or more of the following business purposes:
+
+- To fulfill or meet the reason you provided the information. For example, if you request to be included on an email list or in a user group, we will use that personal information to respond to your request. If you provide your personal information to enter into a smart contract, we will use that information for that purpose. We may also save your information to facilitate your future use of our Network.
+- To process your requests, purchases, transactions, and payments and prevent transactional fraud.
+- To provide you with support and to respond to your inquiries, including to investigate and address your concerns and monitor and improve our responses.
+- To respond to law enforcement requests and as required by applicable law, court order, or governmental regulations.
+- As described to you when collecting your personal information or as otherwise set forth in the CCPA.
+
+KEEP SECZ will not collect additional categories of personal information or use the personal information we collected for materially different, unrelated, or incompatible purposes without providing you notice.
+
+## Sharing Personal Information
+
+KEEP SECZ may disclose your personal information to a third party for a business purpose. When we disclose personal information for a business purpose, we enter a contract that describes the purpose and requires the recipient to both keep that personal information confidential and not use it for any purpose except performing the contract.
+
+We may share your personal information with the following categories of third parties:
+
+- Service providers.
+
+**_Disclosures of Personal Information for a Business Purpose_**
+
+In the preceding twelve (12) months, Keep SECZ has not disclosed personal information for a business purpose.
+
+We may disclose your personal information for a business purpose to the following categories of third parties:
+
+- Service providers.
+
+**_Sales of Personal Information_**
+
+In the preceding twelve (12) months, Keep SECZ has not sold personal information.
+
+## Your Rights and Choices
+
+The CCPA provides consumers (California residents) with specific rights regarding their personal information. This section describes your CCPA rights and explains how to exercise those rights.
+
+**_Access to Specific Information and Data Portability Rights_**
+
+You have the right to request that KEEP SECZ disclose certain information to you about our collection and use of your personal information over the past 12 months. Once we receive and confirm your verifiable consumer request (see Exercising Access, Data Portability, and Deletion Rights), we will disclose to you:
+
+- The categories of personal information we collected about you.
+- The categories of sources for the personal information we collected about you.
+- Our business or commercial purpose for collecting or selling that personal information.
+- The categories of third parties with whom we share that personal information.
+- The specific pieces of personal information we collected about you (also called a data portability request).
+- If we sold or disclosed your personal information for a business purpose, two separate lists disclosing:
+  - sales, identifying the personal information categories that each category of recipient purchased; and
+  - disclosures for a business purpose, identifying the personal information categories that each category of recipient obtained.
+
+**_Deletion Request Rights_**
+
+You have the right to request that KEEP SECZ delete any of your personal information that we collected from you and retained, subject to certain exceptions. Once we receive and confirm your verifiable consumer request (see Exercising Access, Data Portability, and Deletion Rights), we will delete (and direct our service providers to delete) your personal information from our records, unless an exception applies. You acknowledge and agree that we will not be able to delete transactional histories involving your Ethereum wallet address from the Ethereum Blockchain ledger.
+
+We may deny your deletion request if retaining the information is necessary for us or our service provider(s) to:
+
+1. Complete the transaction for which we collected the personal information, provide a good or service that you requested, take actions reasonably anticipated within the context of our ongoing business relationship with you, or otherwise perform our contract with you.
+2. Detect security incidents, protect against malicious, deceptive, fraudulent, or illegal activity, or prosecute those responsible for such activities.
+3. Debug products to identify and repair errors that impair existing intended functionality.
+4. Exercise free speech, ensure the right of another consumer to exercise their free speech rights, or exercise another right provided for by law.
+5. Comply with the California Electronic Communications Privacy Act (Cal. Penal Code § 1546 _et. seq._).
+6. Enable solely internal uses that are reasonably aligned with consumer expectations based on your relationship with us.
+7. Comply with a legal obligation.
+8. Make other internal and lawful uses of that information that are compatible with the context in which you provided it.
+
+**_Exercising Access, Data Portability, and Deletion Rights_**
+
+To exercise the access, data portability, and deletion rights described above, please submit a verifiable consumer request to us by either:
+
+- Emailing us at: [legal@keep.network](mailto:legal@keep.network).
+
+Only you, or a person registered with the California Secretary of State that you authorize to act on your behalf, may make a verifiable consumer request related to your personal information. You may also make a verifiable consumer request on behalf of your minor child.
+
+You may only make a verifiable consumer request for access or data portability twice within a 12-month period. The verifiable consumer request must:
+
+- Provide sufficient information that allows us to reasonably verify you are the person about whom we collected personal information or an authorized representative.
+- Describe your request with sufficient detail that allows us to properly understand, evaluate, and respond to it.
+
+We cannot respond to your request or provide you with personal information if we cannot verify your identity or authority to make the request and confirm the personal information relates to you.
+
+Making a verifiable consumer request does not require you to create an account with us.
+
+We will only use personal information provided in a verifiable consumer request to verify the requestor&#39;s identity or authority to make the request.
+
+For instructions on exercising sale opt-out rights, see Personal Information Sales Opt-Out and Opt-In Rights.
+
+**_Response Timing and Format_**
+
+We endeavor to respond to a verifiable consumer request within forty-five (45) days of its receipt. If we require more time, we will inform you of the reason and extension period in writing. We will deliver our written response to the email address from which you submit it.
+
+Any disclosures we provide will only cover the 12-month period preceding the verifiable consumer request&#39;s receipt. The response we provide will also explain the reasons we cannot comply with a request, if applicable.
+
+We do not charge a fee to process or respond to your verifiable consumer request unless it is excessive, repetitive, or manifestly unfounded. If we determine that the request warrants a fee, we will tell you why we made that decision and provide you with a cost estimate before completing your request.
+
+**_Personal Information Sales Opt-Out and Opt-In Rights_**
+
+We do not sell your personal information so there is no reason for you to opt out of such sales.
+
+## Non-Discrimination
+
+We will not discriminate against you for exercising any of your CCPA rights. Unless permitted by the CCPA, we will not:
+
+- Deny you goods or services.
+- Charge you different prices or rates for goods or services, including through granting discounts or other benefits, or imposing penalties.
+- Provide you a different level or quality of goods or services.
+- Suggest that you may receive a different price or rate for goods or services or a different level or quality of goods or services.
+
+## Other California Privacy Rights
+
+California&#39;s &quot;Shine the Light&quot; law (Civil Code Section § 1798.83) permits users of our Website that are California residents to request certain information regarding our disclosure of personal information to third parties for their direct marketing purposes. We do not disclose personal information for marketing purposes so there is no need to make such a request.
+
+## Changes to Our Privacy Notice
+
+KEEP SECZreserves the right to amend this privacy notice at our discretion and at any time. When we make changes to this privacy notice, we will post the updated notice on the Website and update the notice&#39;s effective date. **Your continued use of our Website following the posting of changes constitutes your acceptance of such changes**.
+
+## Contact Information
+
+If you have any questions or comments about this notice, the ways in which KEEP SECZ collects and uses your information, your choices and rights regarding such use, or wish to exercise your rights under California law, please do not hesitate to contact us at:
+
+**Email**: [legal@keep.network](mailto:legal@keep.network)

--- a/src/pages/california-privacy-notice/index.es.md
+++ b/src/pages/california-privacy-notice/index.es.md
@@ -1,0 +1,158 @@
+---
+template: 'legal-page'
+path: /california-privacy-notice
+title: KEEP SECZ Privacy Notice for California Residents
+---
+**Effective Date:** - April 16, 2020
+
+This **Privacy Notice for California Residents** supplements the information contained in KEEP SECZ&#39;s [Privacy Policy](/privacy-policy) and applies solely to all visitors, users, and others who reside in the State of California (&quot;consumers&quot; or &quot;you&quot;). We adopt this notice to comply with the California Consumer Privacy Act of 2018 (CCPA) and any terms defined in the CCPA have the same meaning when used in this notice.
+
+## Information We Collect
+
+Our Website may collect information that identifies, relates to, describes, references, is capable of being associated with, or could reasonably be linked, directly or indirectly, with a particular consumer or device (&quot; **personal information**&quot;). In particular, our Website collects the following categories of personal information from its consumers within the last twelve (12) months:
+
+| **Category** | **Examples** | **Collected** |
+| --- | --- | --- |
+| A. Identifiers. | Email address, Ethereum Wallet address | YES |
+| B. Personal information categories listed in the California Customer Records statute (Cal. Civ. Code § 1798.80(e)). | A name, signature, Social Security number, physical characteristics or description, address, telephone number, passport number, driver&#39;s license or state identification card number, insurance policy number, education, employment, employment history, account number, credit card number, debit card number, or any other financial information, medical information, or health insurance information.Some personal information included in this category may overlap with other categories. | YES |
+| C. Protected classification characteristics under California or federal law. | Age (40 years or older), race, color, ancestry, national origin, citizenship, religion or creed, marital status, medical condition, physical or mental disability, sex (including gender, gender identity, gender expression, pregnancy or childbirth and related medical conditions), sexual orientation, veteran or military status, genetic information (including familial genetic information).| NO |
+| D. Commercial information. | Records of personal property, products or services purchased, obtained, or considered, or other purchasing or consuming histories or tendencies. | NO |
+| E. Biometric information. | Genetic, physiological, behavioral, and biological characteristics, or activity patterns used to extract a template or other identifier or identifying information, such as, fingerprints, faceprints, and voiceprints, iris or retina scans, keystroke, gait, or other physical patterns, and sleep, health, or exercise data. | NO |
+| F. Internet or other similar network activity. | Browsing history, search history, information on a consumer&#39;s interaction with a website, application, or advertisement. | NO |
+| G. Geolocation data. | Physical location or movements. | NO |
+| H. Sensory data. | Audio, electronic, visual, thermal, olfactory, or similar information. | NO |
+| I. Professional or employment-related information. | Current or past job history or performance evaluations. | NO |
+| J. Non-public education information (per the Family Educational Rights and Privacy Act (20 U.S.C. Section 1232g, 34 C.F.R. Part 99)). | Education records directly related to a student maintained by an educational institution or party acting on its behalf, such as grades, transcripts, class lists, student schedules, student identification codes, student financial information, or student disciplinary records. | NO |
+| K. Inferences drawn from other personal information. | Profile reflecting a person&#39;s preferences, characteristics, psychological trends, predispositions, behavior, attitudes, intelligence, abilities, and aptitudes. | NO |
+
+Personal information does not include:
+
+- Publicly available information from government records.
+- Deidentified or aggregated consumer information.
+- Information excluded from the CCPA&#39;s scope, like:
+  - health or medical information covered by the Health Insurance Portability and Accountability Act of 1996 (HIPAA) and the California Confidentiality of Medical Information Act (CMIA) or clinical trial data;
+  - personal information covered by certain sector-specific privacy laws, including the Fair Credit Reporting Act (FRCA), the Gramm-Leach-Bliley Act (GLBA) or California Financial Information Privacy Act (FIPA), and the Driver&#39;s Privacy Protection Act of 1994.
+
+KEEP SECZ obtains the categories of personal information listed above from the following categories of sources:
+
+- Directly from you. For example, from forms you complete or products you use.
+
+## Use of Personal Information
+
+We may use or disclose the personal information we collect for one or more of the following business purposes:
+
+- To fulfill or meet the reason you provided the information. For example, if you request to be included on an email list or in a user group, we will use that personal information to respond to your request. If you provide your personal information to enter into a smart contract, we will use that information for that purpose. We may also save your information to facilitate your future use of our Network.
+- To process your requests, purchases, transactions, and payments and prevent transactional fraud.
+- To provide you with support and to respond to your inquiries, including to investigate and address your concerns and monitor and improve our responses.
+- To respond to law enforcement requests and as required by applicable law, court order, or governmental regulations.
+- As described to you when collecting your personal information or as otherwise set forth in the CCPA.
+
+KEEP SECZ will not collect additional categories of personal information or use the personal information we collected for materially different, unrelated, or incompatible purposes without providing you notice.
+
+## Sharing Personal Information
+
+KEEP SECZ may disclose your personal information to a third party for a business purpose. When we disclose personal information for a business purpose, we enter a contract that describes the purpose and requires the recipient to both keep that personal information confidential and not use it for any purpose except performing the contract.
+
+We may share your personal information with the following categories of third parties:
+
+- Service providers.
+
+**_Disclosures of Personal Information for a Business Purpose_**
+
+In the preceding twelve (12) months, Keep SECZ has not disclosed personal information for a business purpose.
+
+We may disclose your personal information for a business purpose to the following categories of third parties:
+
+- Service providers.
+
+**_Sales of Personal Information_**
+
+In the preceding twelve (12) months, Keep SECZ has not sold personal information.
+
+## Your Rights and Choices
+
+The CCPA provides consumers (California residents) with specific rights regarding their personal information. This section describes your CCPA rights and explains how to exercise those rights.
+
+**_Access to Specific Information and Data Portability Rights_**
+
+You have the right to request that KEEP SECZ disclose certain information to you about our collection and use of your personal information over the past 12 months. Once we receive and confirm your verifiable consumer request (see Exercising Access, Data Portability, and Deletion Rights), we will disclose to you:
+
+- The categories of personal information we collected about you.
+- The categories of sources for the personal information we collected about you.
+- Our business or commercial purpose for collecting or selling that personal information.
+- The categories of third parties with whom we share that personal information.
+- The specific pieces of personal information we collected about you (also called a data portability request).
+- If we sold or disclosed your personal information for a business purpose, two separate lists disclosing:
+  - sales, identifying the personal information categories that each category of recipient purchased; and
+  - disclosures for a business purpose, identifying the personal information categories that each category of recipient obtained.
+
+**_Deletion Request Rights_**
+
+You have the right to request that KEEP SECZ delete any of your personal information that we collected from you and retained, subject to certain exceptions. Once we receive and confirm your verifiable consumer request (see Exercising Access, Data Portability, and Deletion Rights), we will delete (and direct our service providers to delete) your personal information from our records, unless an exception applies. You acknowledge and agree that we will not be able to delete transactional histories involving your Ethereum wallet address from the Ethereum Blockchain ledger.
+
+We may deny your deletion request if retaining the information is necessary for us or our service provider(s) to:
+
+1. Complete the transaction for which we collected the personal information, provide a good or service that you requested, take actions reasonably anticipated within the context of our ongoing business relationship with you, or otherwise perform our contract with you.
+2. Detect security incidents, protect against malicious, deceptive, fraudulent, or illegal activity, or prosecute those responsible for such activities.
+3. Debug products to identify and repair errors that impair existing intended functionality.
+4. Exercise free speech, ensure the right of another consumer to exercise their free speech rights, or exercise another right provided for by law.
+5. Comply with the California Electronic Communications Privacy Act (Cal. Penal Code § 1546 _et. seq._).
+6. Enable solely internal uses that are reasonably aligned with consumer expectations based on your relationship with us.
+7. Comply with a legal obligation.
+8. Make other internal and lawful uses of that information that are compatible with the context in which you provided it.
+
+**_Exercising Access, Data Portability, and Deletion Rights_**
+
+To exercise the access, data portability, and deletion rights described above, please submit a verifiable consumer request to us by either:
+
+- Emailing us at: [legal@keep.network](mailto:legal@keep.network).
+
+Only you, or a person registered with the California Secretary of State that you authorize to act on your behalf, may make a verifiable consumer request related to your personal information. You may also make a verifiable consumer request on behalf of your minor child.
+
+You may only make a verifiable consumer request for access or data portability twice within a 12-month period. The verifiable consumer request must:
+
+- Provide sufficient information that allows us to reasonably verify you are the person about whom we collected personal information or an authorized representative.
+- Describe your request with sufficient detail that allows us to properly understand, evaluate, and respond to it.
+
+We cannot respond to your request or provide you with personal information if we cannot verify your identity or authority to make the request and confirm the personal information relates to you.
+
+Making a verifiable consumer request does not require you to create an account with us.
+
+We will only use personal information provided in a verifiable consumer request to verify the requestor&#39;s identity or authority to make the request.
+
+For instructions on exercising sale opt-out rights, see Personal Information Sales Opt-Out and Opt-In Rights.
+
+**_Response Timing and Format_**
+
+We endeavor to respond to a verifiable consumer request within forty-five (45) days of its receipt. If we require more time, we will inform you of the reason and extension period in writing. We will deliver our written response to the email address from which you submit it.
+
+Any disclosures we provide will only cover the 12-month period preceding the verifiable consumer request&#39;s receipt. The response we provide will also explain the reasons we cannot comply with a request, if applicable.
+
+We do not charge a fee to process or respond to your verifiable consumer request unless it is excessive, repetitive, or manifestly unfounded. If we determine that the request warrants a fee, we will tell you why we made that decision and provide you with a cost estimate before completing your request.
+
+**_Personal Information Sales Opt-Out and Opt-In Rights_**
+
+We do not sell your personal information so there is no reason for you to opt out of such sales.
+
+## Non-Discrimination
+
+We will not discriminate against you for exercising any of your CCPA rights. Unless permitted by the CCPA, we will not:
+
+- Deny you goods or services.
+- Charge you different prices or rates for goods or services, including through granting discounts or other benefits, or imposing penalties.
+- Provide you a different level or quality of goods or services.
+- Suggest that you may receive a different price or rate for goods or services or a different level or quality of goods or services.
+
+## Other California Privacy Rights
+
+California&#39;s &quot;Shine the Light&quot; law (Civil Code Section § 1798.83) permits users of our Website that are California residents to request certain information regarding our disclosure of personal information to third parties for their direct marketing purposes. We do not disclose personal information for marketing purposes so there is no need to make such a request.
+
+## Changes to Our Privacy Notice
+
+KEEP SECZreserves the right to amend this privacy notice at our discretion and at any time. When we make changes to this privacy notice, we will post the updated notice on the Website and update the notice&#39;s effective date. **Your continued use of our Website following the posting of changes constitutes your acceptance of such changes**.
+
+## Contact Information
+
+If you have any questions or comments about this notice, the ways in which KEEP SECZ collects and uses your information, your choices and rights regarding such use, or wish to exercise your rights under California law, please do not hesitate to contact us at:
+
+**Email**: [legal@keep.network](mailto:legal@keep.network)

--- a/src/pages/california-privacy-notice/index.fr.md
+++ b/src/pages/california-privacy-notice/index.fr.md
@@ -1,0 +1,158 @@
+---
+template: 'legal-page'
+path: /california-privacy-notice
+title: KEEP SECZ Privacy Notice for California Residents
+---
+**Effective Date:** - April 16, 2020
+
+This **Privacy Notice for California Residents** supplements the information contained in KEEP SECZ&#39;s [Privacy Policy](/privacy-policy) and applies solely to all visitors, users, and others who reside in the State of California (&quot;consumers&quot; or &quot;you&quot;). We adopt this notice to comply with the California Consumer Privacy Act of 2018 (CCPA) and any terms defined in the CCPA have the same meaning when used in this notice.
+
+## Information We Collect
+
+Our Website may collect information that identifies, relates to, describes, references, is capable of being associated with, or could reasonably be linked, directly or indirectly, with a particular consumer or device (&quot; **personal information**&quot;). In particular, our Website collects the following categories of personal information from its consumers within the last twelve (12) months:
+
+| **Category** | **Examples** | **Collected** |
+| --- | --- | --- |
+| A. Identifiers. | Email address, Ethereum Wallet address | YES |
+| B. Personal information categories listed in the California Customer Records statute (Cal. Civ. Code § 1798.80(e)). | A name, signature, Social Security number, physical characteristics or description, address, telephone number, passport number, driver&#39;s license or state identification card number, insurance policy number, education, employment, employment history, account number, credit card number, debit card number, or any other financial information, medical information, or health insurance information.Some personal information included in this category may overlap with other categories. | YES |
+| C. Protected classification characteristics under California or federal law. | Age (40 years or older), race, color, ancestry, national origin, citizenship, religion or creed, marital status, medical condition, physical or mental disability, sex (including gender, gender identity, gender expression, pregnancy or childbirth and related medical conditions), sexual orientation, veteran or military status, genetic information (including familial genetic information).| NO |
+| D. Commercial information. | Records of personal property, products or services purchased, obtained, or considered, or other purchasing or consuming histories or tendencies. | NO |
+| E. Biometric information. | Genetic, physiological, behavioral, and biological characteristics, or activity patterns used to extract a template or other identifier or identifying information, such as, fingerprints, faceprints, and voiceprints, iris or retina scans, keystroke, gait, or other physical patterns, and sleep, health, or exercise data. | NO |
+| F. Internet or other similar network activity. | Browsing history, search history, information on a consumer&#39;s interaction with a website, application, or advertisement. | NO |
+| G. Geolocation data. | Physical location or movements. | NO |
+| H. Sensory data. | Audio, electronic, visual, thermal, olfactory, or similar information. | NO |
+| I. Professional or employment-related information. | Current or past job history or performance evaluations. | NO |
+| J. Non-public education information (per the Family Educational Rights and Privacy Act (20 U.S.C. Section 1232g, 34 C.F.R. Part 99)). | Education records directly related to a student maintained by an educational institution or party acting on its behalf, such as grades, transcripts, class lists, student schedules, student identification codes, student financial information, or student disciplinary records. | NO |
+| K. Inferences drawn from other personal information. | Profile reflecting a person&#39;s preferences, characteristics, psychological trends, predispositions, behavior, attitudes, intelligence, abilities, and aptitudes. | NO |
+
+Personal information does not include:
+
+- Publicly available information from government records.
+- Deidentified or aggregated consumer information.
+- Information excluded from the CCPA&#39;s scope, like:
+  - health or medical information covered by the Health Insurance Portability and Accountability Act of 1996 (HIPAA) and the California Confidentiality of Medical Information Act (CMIA) or clinical trial data;
+  - personal information covered by certain sector-specific privacy laws, including the Fair Credit Reporting Act (FRCA), the Gramm-Leach-Bliley Act (GLBA) or California Financial Information Privacy Act (FIPA), and the Driver&#39;s Privacy Protection Act of 1994.
+
+KEEP SECZ obtains the categories of personal information listed above from the following categories of sources:
+
+- Directly from you. For example, from forms you complete or products you use.
+
+## Use of Personal Information
+
+We may use or disclose the personal information we collect for one or more of the following business purposes:
+
+- To fulfill or meet the reason you provided the information. For example, if you request to be included on an email list or in a user group, we will use that personal information to respond to your request. If you provide your personal information to enter into a smart contract, we will use that information for that purpose. We may also save your information to facilitate your future use of our Network.
+- To process your requests, purchases, transactions, and payments and prevent transactional fraud.
+- To provide you with support and to respond to your inquiries, including to investigate and address your concerns and monitor and improve our responses.
+- To respond to law enforcement requests and as required by applicable law, court order, or governmental regulations.
+- As described to you when collecting your personal information or as otherwise set forth in the CCPA.
+
+KEEP SECZ will not collect additional categories of personal information or use the personal information we collected for materially different, unrelated, or incompatible purposes without providing you notice.
+
+## Sharing Personal Information
+
+KEEP SECZ may disclose your personal information to a third party for a business purpose. When we disclose personal information for a business purpose, we enter a contract that describes the purpose and requires the recipient to both keep that personal information confidential and not use it for any purpose except performing the contract.
+
+We may share your personal information with the following categories of third parties:
+
+- Service providers.
+
+**_Disclosures of Personal Information for a Business Purpose_**
+
+In the preceding twelve (12) months, Keep SECZ has not disclosed personal information for a business purpose.
+
+We may disclose your personal information for a business purpose to the following categories of third parties:
+
+- Service providers.
+
+**_Sales of Personal Information_**
+
+In the preceding twelve (12) months, Keep SECZ has not sold personal information.
+
+## Your Rights and Choices
+
+The CCPA provides consumers (California residents) with specific rights regarding their personal information. This section describes your CCPA rights and explains how to exercise those rights.
+
+**_Access to Specific Information and Data Portability Rights_**
+
+You have the right to request that KEEP SECZ disclose certain information to you about our collection and use of your personal information over the past 12 months. Once we receive and confirm your verifiable consumer request (see Exercising Access, Data Portability, and Deletion Rights), we will disclose to you:
+
+- The categories of personal information we collected about you.
+- The categories of sources for the personal information we collected about you.
+- Our business or commercial purpose for collecting or selling that personal information.
+- The categories of third parties with whom we share that personal information.
+- The specific pieces of personal information we collected about you (also called a data portability request).
+- If we sold or disclosed your personal information for a business purpose, two separate lists disclosing:
+  - sales, identifying the personal information categories that each category of recipient purchased; and
+  - disclosures for a business purpose, identifying the personal information categories that each category of recipient obtained.
+
+**_Deletion Request Rights_**
+
+You have the right to request that KEEP SECZ delete any of your personal information that we collected from you and retained, subject to certain exceptions. Once we receive and confirm your verifiable consumer request (see Exercising Access, Data Portability, and Deletion Rights), we will delete (and direct our service providers to delete) your personal information from our records, unless an exception applies. You acknowledge and agree that we will not be able to delete transactional histories involving your Ethereum wallet address from the Ethereum Blockchain ledger.
+
+We may deny your deletion request if retaining the information is necessary for us or our service provider(s) to:
+
+1. Complete the transaction for which we collected the personal information, provide a good or service that you requested, take actions reasonably anticipated within the context of our ongoing business relationship with you, or otherwise perform our contract with you.
+2. Detect security incidents, protect against malicious, deceptive, fraudulent, or illegal activity, or prosecute those responsible for such activities.
+3. Debug products to identify and repair errors that impair existing intended functionality.
+4. Exercise free speech, ensure the right of another consumer to exercise their free speech rights, or exercise another right provided for by law.
+5. Comply with the California Electronic Communications Privacy Act (Cal. Penal Code § 1546 _et. seq._).
+6. Enable solely internal uses that are reasonably aligned with consumer expectations based on your relationship with us.
+7. Comply with a legal obligation.
+8. Make other internal and lawful uses of that information that are compatible with the context in which you provided it.
+
+**_Exercising Access, Data Portability, and Deletion Rights_**
+
+To exercise the access, data portability, and deletion rights described above, please submit a verifiable consumer request to us by either:
+
+- Emailing us at: [legal@keep.network](mailto:legal@keep.network).
+
+Only you, or a person registered with the California Secretary of State that you authorize to act on your behalf, may make a verifiable consumer request related to your personal information. You may also make a verifiable consumer request on behalf of your minor child.
+
+You may only make a verifiable consumer request for access or data portability twice within a 12-month period. The verifiable consumer request must:
+
+- Provide sufficient information that allows us to reasonably verify you are the person about whom we collected personal information or an authorized representative.
+- Describe your request with sufficient detail that allows us to properly understand, evaluate, and respond to it.
+
+We cannot respond to your request or provide you with personal information if we cannot verify your identity or authority to make the request and confirm the personal information relates to you.
+
+Making a verifiable consumer request does not require you to create an account with us.
+
+We will only use personal information provided in a verifiable consumer request to verify the requestor&#39;s identity or authority to make the request.
+
+For instructions on exercising sale opt-out rights, see Personal Information Sales Opt-Out and Opt-In Rights.
+
+**_Response Timing and Format_**
+
+We endeavor to respond to a verifiable consumer request within forty-five (45) days of its receipt. If we require more time, we will inform you of the reason and extension period in writing. We will deliver our written response to the email address from which you submit it.
+
+Any disclosures we provide will only cover the 12-month period preceding the verifiable consumer request&#39;s receipt. The response we provide will also explain the reasons we cannot comply with a request, if applicable.
+
+We do not charge a fee to process or respond to your verifiable consumer request unless it is excessive, repetitive, or manifestly unfounded. If we determine that the request warrants a fee, we will tell you why we made that decision and provide you with a cost estimate before completing your request.
+
+**_Personal Information Sales Opt-Out and Opt-In Rights_**
+
+We do not sell your personal information so there is no reason for you to opt out of such sales.
+
+## Non-Discrimination
+
+We will not discriminate against you for exercising any of your CCPA rights. Unless permitted by the CCPA, we will not:
+
+- Deny you goods or services.
+- Charge you different prices or rates for goods or services, including through granting discounts or other benefits, or imposing penalties.
+- Provide you a different level or quality of goods or services.
+- Suggest that you may receive a different price or rate for goods or services or a different level or quality of goods or services.
+
+## Other California Privacy Rights
+
+California&#39;s &quot;Shine the Light&quot; law (Civil Code Section § 1798.83) permits users of our Website that are California residents to request certain information regarding our disclosure of personal information to third parties for their direct marketing purposes. We do not disclose personal information for marketing purposes so there is no need to make such a request.
+
+## Changes to Our Privacy Notice
+
+KEEP SECZreserves the right to amend this privacy notice at our discretion and at any time. When we make changes to this privacy notice, we will post the updated notice on the Website and update the notice&#39;s effective date. **Your continued use of our Website following the posting of changes constitutes your acceptance of such changes**.
+
+## Contact Information
+
+If you have any questions or comments about this notice, the ways in which KEEP SECZ collects and uses your information, your choices and rights regarding such use, or wish to exercise your rights under California law, please do not hesitate to contact us at:
+
+**Email**: [legal@keep.network](mailto:legal@keep.network)

--- a/src/pages/california-privacy-notice/index.pl.md
+++ b/src/pages/california-privacy-notice/index.pl.md
@@ -1,0 +1,158 @@
+---
+template: 'legal-page'
+path: /california-privacy-notice
+title: KEEP SECZ Privacy Notice for California Residents
+---
+**Effective Date:** - April 16, 2020
+
+This **Privacy Notice for California Residents** supplements the information contained in KEEP SECZ&#39;s [Privacy Policy](/privacy-policy) and applies solely to all visitors, users, and others who reside in the State of California (&quot;consumers&quot; or &quot;you&quot;). We adopt this notice to comply with the California Consumer Privacy Act of 2018 (CCPA) and any terms defined in the CCPA have the same meaning when used in this notice.
+
+## Information We Collect
+
+Our Website may collect information that identifies, relates to, describes, references, is capable of being associated with, or could reasonably be linked, directly or indirectly, with a particular consumer or device (&quot; **personal information**&quot;). In particular, our Website collects the following categories of personal information from its consumers within the last twelve (12) months:
+
+| **Category** | **Examples** | **Collected** |
+| --- | --- | --- |
+| A. Identifiers. | Email address, Ethereum Wallet address | YES |
+| B. Personal information categories listed in the California Customer Records statute (Cal. Civ. Code § 1798.80(e)). | A name, signature, Social Security number, physical characteristics or description, address, telephone number, passport number, driver&#39;s license or state identification card number, insurance policy number, education, employment, employment history, account number, credit card number, debit card number, or any other financial information, medical information, or health insurance information.Some personal information included in this category may overlap with other categories. | YES |
+| C. Protected classification characteristics under California or federal law. | Age (40 years or older), race, color, ancestry, national origin, citizenship, religion or creed, marital status, medical condition, physical or mental disability, sex (including gender, gender identity, gender expression, pregnancy or childbirth and related medical conditions), sexual orientation, veteran or military status, genetic information (including familial genetic information).| NO |
+| D. Commercial information. | Records of personal property, products or services purchased, obtained, or considered, or other purchasing or consuming histories or tendencies. | NO |
+| E. Biometric information. | Genetic, physiological, behavioral, and biological characteristics, or activity patterns used to extract a template or other identifier or identifying information, such as, fingerprints, faceprints, and voiceprints, iris or retina scans, keystroke, gait, or other physical patterns, and sleep, health, or exercise data. | NO |
+| F. Internet or other similar network activity. | Browsing history, search history, information on a consumer&#39;s interaction with a website, application, or advertisement. | NO |
+| G. Geolocation data. | Physical location or movements. | NO |
+| H. Sensory data. | Audio, electronic, visual, thermal, olfactory, or similar information. | NO |
+| I. Professional or employment-related information. | Current or past job history or performance evaluations. | NO |
+| J. Non-public education information (per the Family Educational Rights and Privacy Act (20 U.S.C. Section 1232g, 34 C.F.R. Part 99)). | Education records directly related to a student maintained by an educational institution or party acting on its behalf, such as grades, transcripts, class lists, student schedules, student identification codes, student financial information, or student disciplinary records. | NO |
+| K. Inferences drawn from other personal information. | Profile reflecting a person&#39;s preferences, characteristics, psychological trends, predispositions, behavior, attitudes, intelligence, abilities, and aptitudes. | NO |
+
+Personal information does not include:
+
+- Publicly available information from government records.
+- Deidentified or aggregated consumer information.
+- Information excluded from the CCPA&#39;s scope, like:
+  - health or medical information covered by the Health Insurance Portability and Accountability Act of 1996 (HIPAA) and the California Confidentiality of Medical Information Act (CMIA) or clinical trial data;
+  - personal information covered by certain sector-specific privacy laws, including the Fair Credit Reporting Act (FRCA), the Gramm-Leach-Bliley Act (GLBA) or California Financial Information Privacy Act (FIPA), and the Driver&#39;s Privacy Protection Act of 1994.
+
+KEEP SECZ obtains the categories of personal information listed above from the following categories of sources:
+
+- Directly from you. For example, from forms you complete or products you use.
+
+## Use of Personal Information
+
+We may use or disclose the personal information we collect for one or more of the following business purposes:
+
+- To fulfill or meet the reason you provided the information. For example, if you request to be included on an email list or in a user group, we will use that personal information to respond to your request. If you provide your personal information to enter into a smart contract, we will use that information for that purpose. We may also save your information to facilitate your future use of our Network.
+- To process your requests, purchases, transactions, and payments and prevent transactional fraud.
+- To provide you with support and to respond to your inquiries, including to investigate and address your concerns and monitor and improve our responses.
+- To respond to law enforcement requests and as required by applicable law, court order, or governmental regulations.
+- As described to you when collecting your personal information or as otherwise set forth in the CCPA.
+
+KEEP SECZ will not collect additional categories of personal information or use the personal information we collected for materially different, unrelated, or incompatible purposes without providing you notice.
+
+## Sharing Personal Information
+
+KEEP SECZ may disclose your personal information to a third party for a business purpose. When we disclose personal information for a business purpose, we enter a contract that describes the purpose and requires the recipient to both keep that personal information confidential and not use it for any purpose except performing the contract.
+
+We may share your personal information with the following categories of third parties:
+
+- Service providers.
+
+**_Disclosures of Personal Information for a Business Purpose_**
+
+In the preceding twelve (12) months, Keep SECZ has not disclosed personal information for a business purpose.
+
+We may disclose your personal information for a business purpose to the following categories of third parties:
+
+- Service providers.
+
+**_Sales of Personal Information_**
+
+In the preceding twelve (12) months, Keep SECZ has not sold personal information.
+
+## Your Rights and Choices
+
+The CCPA provides consumers (California residents) with specific rights regarding their personal information. This section describes your CCPA rights and explains how to exercise those rights.
+
+**_Access to Specific Information and Data Portability Rights_**
+
+You have the right to request that KEEP SECZ disclose certain information to you about our collection and use of your personal information over the past 12 months. Once we receive and confirm your verifiable consumer request (see Exercising Access, Data Portability, and Deletion Rights), we will disclose to you:
+
+- The categories of personal information we collected about you.
+- The categories of sources for the personal information we collected about you.
+- Our business or commercial purpose for collecting or selling that personal information.
+- The categories of third parties with whom we share that personal information.
+- The specific pieces of personal information we collected about you (also called a data portability request).
+- If we sold or disclosed your personal information for a business purpose, two separate lists disclosing:
+  - sales, identifying the personal information categories that each category of recipient purchased; and
+  - disclosures for a business purpose, identifying the personal information categories that each category of recipient obtained.
+
+**_Deletion Request Rights_**
+
+You have the right to request that KEEP SECZ delete any of your personal information that we collected from you and retained, subject to certain exceptions. Once we receive and confirm your verifiable consumer request (see Exercising Access, Data Portability, and Deletion Rights), we will delete (and direct our service providers to delete) your personal information from our records, unless an exception applies. You acknowledge and agree that we will not be able to delete transactional histories involving your Ethereum wallet address from the Ethereum Blockchain ledger.
+
+We may deny your deletion request if retaining the information is necessary for us or our service provider(s) to:
+
+1. Complete the transaction for which we collected the personal information, provide a good or service that you requested, take actions reasonably anticipated within the context of our ongoing business relationship with you, or otherwise perform our contract with you.
+2. Detect security incidents, protect against malicious, deceptive, fraudulent, or illegal activity, or prosecute those responsible for such activities.
+3. Debug products to identify and repair errors that impair existing intended functionality.
+4. Exercise free speech, ensure the right of another consumer to exercise their free speech rights, or exercise another right provided for by law.
+5. Comply with the California Electronic Communications Privacy Act (Cal. Penal Code § 1546 _et. seq._).
+6. Enable solely internal uses that are reasonably aligned with consumer expectations based on your relationship with us.
+7. Comply with a legal obligation.
+8. Make other internal and lawful uses of that information that are compatible with the context in which you provided it.
+
+**_Exercising Access, Data Portability, and Deletion Rights_**
+
+To exercise the access, data portability, and deletion rights described above, please submit a verifiable consumer request to us by either:
+
+- Emailing us at: [legal@keep.network](mailto:legal@keep.network).
+
+Only you, or a person registered with the California Secretary of State that you authorize to act on your behalf, may make a verifiable consumer request related to your personal information. You may also make a verifiable consumer request on behalf of your minor child.
+
+You may only make a verifiable consumer request for access or data portability twice within a 12-month period. The verifiable consumer request must:
+
+- Provide sufficient information that allows us to reasonably verify you are the person about whom we collected personal information or an authorized representative.
+- Describe your request with sufficient detail that allows us to properly understand, evaluate, and respond to it.
+
+We cannot respond to your request or provide you with personal information if we cannot verify your identity or authority to make the request and confirm the personal information relates to you.
+
+Making a verifiable consumer request does not require you to create an account with us.
+
+We will only use personal information provided in a verifiable consumer request to verify the requestor&#39;s identity or authority to make the request.
+
+For instructions on exercising sale opt-out rights, see Personal Information Sales Opt-Out and Opt-In Rights.
+
+**_Response Timing and Format_**
+
+We endeavor to respond to a verifiable consumer request within forty-five (45) days of its receipt. If we require more time, we will inform you of the reason and extension period in writing. We will deliver our written response to the email address from which you submit it.
+
+Any disclosures we provide will only cover the 12-month period preceding the verifiable consumer request&#39;s receipt. The response we provide will also explain the reasons we cannot comply with a request, if applicable.
+
+We do not charge a fee to process or respond to your verifiable consumer request unless it is excessive, repetitive, or manifestly unfounded. If we determine that the request warrants a fee, we will tell you why we made that decision and provide you with a cost estimate before completing your request.
+
+**_Personal Information Sales Opt-Out and Opt-In Rights_**
+
+We do not sell your personal information so there is no reason for you to opt out of such sales.
+
+## Non-Discrimination
+
+We will not discriminate against you for exercising any of your CCPA rights. Unless permitted by the CCPA, we will not:
+
+- Deny you goods or services.
+- Charge you different prices or rates for goods or services, including through granting discounts or other benefits, or imposing penalties.
+- Provide you a different level or quality of goods or services.
+- Suggest that you may receive a different price or rate for goods or services or a different level or quality of goods or services.
+
+## Other California Privacy Rights
+
+California&#39;s &quot;Shine the Light&quot; law (Civil Code Section § 1798.83) permits users of our Website that are California residents to request certain information regarding our disclosure of personal information to third parties for their direct marketing purposes. We do not disclose personal information for marketing purposes so there is no need to make such a request.
+
+## Changes to Our Privacy Notice
+
+KEEP SECZreserves the right to amend this privacy notice at our discretion and at any time. When we make changes to this privacy notice, we will post the updated notice on the Website and update the notice&#39;s effective date. **Your continued use of our Website following the posting of changes constitutes your acceptance of such changes**.
+
+## Contact Information
+
+If you have any questions or comments about this notice, the ways in which KEEP SECZ collects and uses your information, your choices and rights regarding such use, or wish to exercise your rights under California law, please do not hesitate to contact us at:
+
+**Email**: [legal@keep.network](mailto:legal@keep.network)

--- a/src/pages/california-privacy-notice/index.ru.md
+++ b/src/pages/california-privacy-notice/index.ru.md
@@ -1,0 +1,158 @@
+---
+template: 'legal-page'
+path: /california-privacy-notice
+title: KEEP SECZ Privacy Notice for California Residents
+---
+**Effective Date:** - April 16, 2020
+
+This **Privacy Notice for California Residents** supplements the information contained in KEEP SECZ&#39;s [Privacy Policy](/privacy-policy) and applies solely to all visitors, users, and others who reside in the State of California (&quot;consumers&quot; or &quot;you&quot;). We adopt this notice to comply with the California Consumer Privacy Act of 2018 (CCPA) and any terms defined in the CCPA have the same meaning when used in this notice.
+
+## Information We Collect
+
+Our Website may collect information that identifies, relates to, describes, references, is capable of being associated with, or could reasonably be linked, directly or indirectly, with a particular consumer or device (&quot; **personal information**&quot;). In particular, our Website collects the following categories of personal information from its consumers within the last twelve (12) months:
+
+| **Category** | **Examples** | **Collected** |
+| --- | --- | --- |
+| A. Identifiers. | Email address, Ethereum Wallet address | YES |
+| B. Personal information categories listed in the California Customer Records statute (Cal. Civ. Code § 1798.80(e)). | A name, signature, Social Security number, physical characteristics or description, address, telephone number, passport number, driver&#39;s license or state identification card number, insurance policy number, education, employment, employment history, account number, credit card number, debit card number, or any other financial information, medical information, or health insurance information.Some personal information included in this category may overlap with other categories. | YES |
+| C. Protected classification characteristics under California or federal law. | Age (40 years or older), race, color, ancestry, national origin, citizenship, religion or creed, marital status, medical condition, physical or mental disability, sex (including gender, gender identity, gender expression, pregnancy or childbirth and related medical conditions), sexual orientation, veteran or military status, genetic information (including familial genetic information).| NO |
+| D. Commercial information. | Records of personal property, products or services purchased, obtained, or considered, or other purchasing or consuming histories or tendencies. | NO |
+| E. Biometric information. | Genetic, physiological, behavioral, and biological characteristics, or activity patterns used to extract a template or other identifier or identifying information, such as, fingerprints, faceprints, and voiceprints, iris or retina scans, keystroke, gait, or other physical patterns, and sleep, health, or exercise data. | NO |
+| F. Internet or other similar network activity. | Browsing history, search history, information on a consumer&#39;s interaction with a website, application, or advertisement. | NO |
+| G. Geolocation data. | Physical location or movements. | NO |
+| H. Sensory data. | Audio, electronic, visual, thermal, olfactory, or similar information. | NO |
+| I. Professional or employment-related information. | Current or past job history or performance evaluations. | NO |
+| J. Non-public education information (per the Family Educational Rights and Privacy Act (20 U.S.C. Section 1232g, 34 C.F.R. Part 99)). | Education records directly related to a student maintained by an educational institution or party acting on its behalf, such as grades, transcripts, class lists, student schedules, student identification codes, student financial information, or student disciplinary records. | NO |
+| K. Inferences drawn from other personal information. | Profile reflecting a person&#39;s preferences, characteristics, psychological trends, predispositions, behavior, attitudes, intelligence, abilities, and aptitudes. | NO |
+
+Personal information does not include:
+
+- Publicly available information from government records.
+- Deidentified or aggregated consumer information.
+- Information excluded from the CCPA&#39;s scope, like:
+  - health or medical information covered by the Health Insurance Portability and Accountability Act of 1996 (HIPAA) and the California Confidentiality of Medical Information Act (CMIA) or clinical trial data;
+  - personal information covered by certain sector-specific privacy laws, including the Fair Credit Reporting Act (FRCA), the Gramm-Leach-Bliley Act (GLBA) or California Financial Information Privacy Act (FIPA), and the Driver&#39;s Privacy Protection Act of 1994.
+
+KEEP SECZ obtains the categories of personal information listed above from the following categories of sources:
+
+- Directly from you. For example, from forms you complete or products you use.
+
+## Use of Personal Information
+
+We may use or disclose the personal information we collect for one or more of the following business purposes:
+
+- To fulfill or meet the reason you provided the information. For example, if you request to be included on an email list or in a user group, we will use that personal information to respond to your request. If you provide your personal information to enter into a smart contract, we will use that information for that purpose. We may also save your information to facilitate your future use of our Network.
+- To process your requests, purchases, transactions, and payments and prevent transactional fraud.
+- To provide you with support and to respond to your inquiries, including to investigate and address your concerns and monitor and improve our responses.
+- To respond to law enforcement requests and as required by applicable law, court order, or governmental regulations.
+- As described to you when collecting your personal information or as otherwise set forth in the CCPA.
+
+KEEP SECZ will not collect additional categories of personal information or use the personal information we collected for materially different, unrelated, or incompatible purposes without providing you notice.
+
+## Sharing Personal Information
+
+KEEP SECZ may disclose your personal information to a third party for a business purpose. When we disclose personal information for a business purpose, we enter a contract that describes the purpose and requires the recipient to both keep that personal information confidential and not use it for any purpose except performing the contract.
+
+We may share your personal information with the following categories of third parties:
+
+- Service providers.
+
+**_Disclosures of Personal Information for a Business Purpose_**
+
+In the preceding twelve (12) months, Keep SECZ has not disclosed personal information for a business purpose.
+
+We may disclose your personal information for a business purpose to the following categories of third parties:
+
+- Service providers.
+
+**_Sales of Personal Information_**
+
+In the preceding twelve (12) months, Keep SECZ has not sold personal information.
+
+## Your Rights and Choices
+
+The CCPA provides consumers (California residents) with specific rights regarding their personal information. This section describes your CCPA rights and explains how to exercise those rights.
+
+**_Access to Specific Information and Data Portability Rights_**
+
+You have the right to request that KEEP SECZ disclose certain information to you about our collection and use of your personal information over the past 12 months. Once we receive and confirm your verifiable consumer request (see Exercising Access, Data Portability, and Deletion Rights), we will disclose to you:
+
+- The categories of personal information we collected about you.
+- The categories of sources for the personal information we collected about you.
+- Our business or commercial purpose for collecting or selling that personal information.
+- The categories of third parties with whom we share that personal information.
+- The specific pieces of personal information we collected about you (also called a data portability request).
+- If we sold or disclosed your personal information for a business purpose, two separate lists disclosing:
+  - sales, identifying the personal information categories that each category of recipient purchased; and
+  - disclosures for a business purpose, identifying the personal information categories that each category of recipient obtained.
+
+**_Deletion Request Rights_**
+
+You have the right to request that KEEP SECZ delete any of your personal information that we collected from you and retained, subject to certain exceptions. Once we receive and confirm your verifiable consumer request (see Exercising Access, Data Portability, and Deletion Rights), we will delete (and direct our service providers to delete) your personal information from our records, unless an exception applies. You acknowledge and agree that we will not be able to delete transactional histories involving your Ethereum wallet address from the Ethereum Blockchain ledger.
+
+We may deny your deletion request if retaining the information is necessary for us or our service provider(s) to:
+
+1. Complete the transaction for which we collected the personal information, provide a good or service that you requested, take actions reasonably anticipated within the context of our ongoing business relationship with you, or otherwise perform our contract with you.
+2. Detect security incidents, protect against malicious, deceptive, fraudulent, or illegal activity, or prosecute those responsible for such activities.
+3. Debug products to identify and repair errors that impair existing intended functionality.
+4. Exercise free speech, ensure the right of another consumer to exercise their free speech rights, or exercise another right provided for by law.
+5. Comply with the California Electronic Communications Privacy Act (Cal. Penal Code § 1546 _et. seq._).
+6. Enable solely internal uses that are reasonably aligned with consumer expectations based on your relationship with us.
+7. Comply with a legal obligation.
+8. Make other internal and lawful uses of that information that are compatible with the context in which you provided it.
+
+**_Exercising Access, Data Portability, and Deletion Rights_**
+
+To exercise the access, data portability, and deletion rights described above, please submit a verifiable consumer request to us by either:
+
+- Emailing us at: [legal@keep.network](mailto:legal@keep.network).
+
+Only you, or a person registered with the California Secretary of State that you authorize to act on your behalf, may make a verifiable consumer request related to your personal information. You may also make a verifiable consumer request on behalf of your minor child.
+
+You may only make a verifiable consumer request for access or data portability twice within a 12-month period. The verifiable consumer request must:
+
+- Provide sufficient information that allows us to reasonably verify you are the person about whom we collected personal information or an authorized representative.
+- Describe your request with sufficient detail that allows us to properly understand, evaluate, and respond to it.
+
+We cannot respond to your request or provide you with personal information if we cannot verify your identity or authority to make the request and confirm the personal information relates to you.
+
+Making a verifiable consumer request does not require you to create an account with us.
+
+We will only use personal information provided in a verifiable consumer request to verify the requestor&#39;s identity or authority to make the request.
+
+For instructions on exercising sale opt-out rights, see Personal Information Sales Opt-Out and Opt-In Rights.
+
+**_Response Timing and Format_**
+
+We endeavor to respond to a verifiable consumer request within forty-five (45) days of its receipt. If we require more time, we will inform you of the reason and extension period in writing. We will deliver our written response to the email address from which you submit it.
+
+Any disclosures we provide will only cover the 12-month period preceding the verifiable consumer request&#39;s receipt. The response we provide will also explain the reasons we cannot comply with a request, if applicable.
+
+We do not charge a fee to process or respond to your verifiable consumer request unless it is excessive, repetitive, or manifestly unfounded. If we determine that the request warrants a fee, we will tell you why we made that decision and provide you with a cost estimate before completing your request.
+
+**_Personal Information Sales Opt-Out and Opt-In Rights_**
+
+We do not sell your personal information so there is no reason for you to opt out of such sales.
+
+## Non-Discrimination
+
+We will not discriminate against you for exercising any of your CCPA rights. Unless permitted by the CCPA, we will not:
+
+- Deny you goods or services.
+- Charge you different prices or rates for goods or services, including through granting discounts or other benefits, or imposing penalties.
+- Provide you a different level or quality of goods or services.
+- Suggest that you may receive a different price or rate for goods or services or a different level or quality of goods or services.
+
+## Other California Privacy Rights
+
+California&#39;s &quot;Shine the Light&quot; law (Civil Code Section § 1798.83) permits users of our Website that are California residents to request certain information regarding our disclosure of personal information to third parties for their direct marketing purposes. We do not disclose personal information for marketing purposes so there is no need to make such a request.
+
+## Changes to Our Privacy Notice
+
+KEEP SECZreserves the right to amend this privacy notice at our discretion and at any time. When we make changes to this privacy notice, we will post the updated notice on the Website and update the notice&#39;s effective date. **Your continued use of our Website following the posting of changes constitutes your acceptance of such changes**.
+
+## Contact Information
+
+If you have any questions or comments about this notice, the ways in which KEEP SECZ collects and uses your information, your choices and rights regarding such use, or wish to exercise your rights under California law, please do not hesitate to contact us at:
+
+**Email**: [legal@keep.network](mailto:legal@keep.network)

--- a/src/pages/developers/index.de.md
+++ b/src/pages/developers/index.de.md
@@ -1,0 +1,15 @@
+---
+template: 'developers-page'
+path: /developers
+title: Build with tBTC
+---
+Developers can build on tBTC. There are several resources to help devs use tBTC infrastructure to bring Bitcoin to Ethereum. Get started with the following resources:
+
+- [How to Integrate TBTC into Your Defi Dapp](/developers/how-to-integrate-tbtc-into-your-defi-dapp)
+- The Ropsten-connected [tBTC dApp](https://dapp.test.tbtc.network/)
+- [tBTC smart contracts](https://github.com/keep-network/tbtc)
+- [tbtc.js](https://github.com/keep-network/tbtc.js)
+- [The technical specification](http://docs.keep.network/tbtc/)
+- [The Solidity API documentation](http://docs.keep.network/tbtc/solidity/)
+
+Developers are already building on tBTC using the tools above. The hackathon at ETHDenver [produced several excellent applications](https://blog.keep.network/bitcoin-earn-wins-ethdenver-tbtc-hackathon-prize-5233ce805468) that may provide examples.

--- a/src/pages/developers/index.es.md
+++ b/src/pages/developers/index.es.md
@@ -1,0 +1,15 @@
+---
+template: 'developers-page'
+path: /developers
+title: Build with tBTC
+---
+Developers can build on tBTC. There are several resources to help devs use tBTC infrastructure to bring Bitcoin to Ethereum. Get started with the following resources:
+
+- [How to Integrate TBTC into Your Defi Dapp](/developers/how-to-integrate-tbtc-into-your-defi-dapp)
+- The Ropsten-connected [tBTC dApp](https://dapp.test.tbtc.network/)
+- [tBTC smart contracts](https://github.com/keep-network/tbtc)
+- [tbtc.js](https://github.com/keep-network/tbtc.js)
+- [The technical specification](http://docs.keep.network/tbtc/)
+- [The Solidity API documentation](http://docs.keep.network/tbtc/solidity/)
+
+Developers are already building on tBTC using the tools above. The hackathon at ETHDenver [produced several excellent applications](https://blog.keep.network/bitcoin-earn-wins-ethdenver-tbtc-hackathon-prize-5233ce805468) that may provide examples.

--- a/src/pages/developers/index.fr.md
+++ b/src/pages/developers/index.fr.md
@@ -1,0 +1,15 @@
+---
+template: 'developers-page'
+path: /developers
+title: Build with tBTC
+---
+Developers can build on tBTC. There are several resources to help devs use tBTC infrastructure to bring Bitcoin to Ethereum. Get started with the following resources:
+
+- [How to Integrate TBTC into Your Defi Dapp](/developers/how-to-integrate-tbtc-into-your-defi-dapp)
+- The Ropsten-connected [tBTC dApp](https://dapp.test.tbtc.network/)
+- [tBTC smart contracts](https://github.com/keep-network/tbtc)
+- [tbtc.js](https://github.com/keep-network/tbtc.js)
+- [The technical specification](http://docs.keep.network/tbtc/)
+- [The Solidity API documentation](http://docs.keep.network/tbtc/solidity/)
+
+Developers are already building on tBTC using the tools above. The hackathon at ETHDenver [produced several excellent applications](https://blog.keep.network/bitcoin-earn-wins-ethdenver-tbtc-hackathon-prize-5233ce805468) that may provide examples.

--- a/src/pages/developers/index.pl.md
+++ b/src/pages/developers/index.pl.md
@@ -1,0 +1,15 @@
+---
+template: 'developers-page'
+path: /developers
+title: Build with tBTC
+---
+Developers can build on tBTC. There are several resources to help devs use tBTC infrastructure to bring Bitcoin to Ethereum. Get started with the following resources:
+
+- [How to Integrate TBTC into Your Defi Dapp](/developers/how-to-integrate-tbtc-into-your-defi-dapp)
+- The Ropsten-connected [tBTC dApp](https://dapp.test.tbtc.network/)
+- [tBTC smart contracts](https://github.com/keep-network/tbtc)
+- [tbtc.js](https://github.com/keep-network/tbtc.js)
+- [The technical specification](http://docs.keep.network/tbtc/)
+- [The Solidity API documentation](http://docs.keep.network/tbtc/solidity/)
+
+Developers are already building on tBTC using the tools above. The hackathon at ETHDenver [produced several excellent applications](https://blog.keep.network/bitcoin-earn-wins-ethdenver-tbtc-hackathon-prize-5233ce805468) that may provide examples.

--- a/src/pages/developers/index.ru.md
+++ b/src/pages/developers/index.ru.md
@@ -1,0 +1,15 @@
+---
+template: 'developers-page'
+path: /developers
+title: Build with tBTC
+---
+Developers can build on tBTC. There are several resources to help devs use tBTC infrastructure to bring Bitcoin to Ethereum. Get started with the following resources:
+
+- [How to Integrate TBTC into Your Defi Dapp](/developers/how-to-integrate-tbtc-into-your-defi-dapp)
+- The Ropsten-connected [tBTC dApp](https://dapp.test.tbtc.network/)
+- [tBTC smart contracts](https://github.com/keep-network/tbtc)
+- [tbtc.js](https://github.com/keep-network/tbtc.js)
+- [The technical specification](http://docs.keep.network/tbtc/)
+- [The Solidity API documentation](http://docs.keep.network/tbtc/solidity/)
+
+Developers are already building on tBTC using the tools above. The hackathon at ETHDenver [produced several excellent applications](https://blog.keep.network/bitcoin-earn-wins-ethdenver-tbtc-hackathon-prize-5233ce805468) that may provide examples.

--- a/src/pages/faq/index.de.md
+++ b/src/pages/faq/index.de.md
@@ -1,0 +1,57 @@
+---
+template: 'faq-page'
+path: /faq
+title: FAQ
+questions:
+  - question: How does tBTC maintain the peg?
+    answer: >
+      tBTC does not maintain the peg. It’s a supply peg not a price peg, so there is no algorithmic mechanism needed to function as a decentralized peg.
+  - question: Why is the TBTC price not exactly the same as BTC?
+    answer: >
+      tBTC is not a price peg to BTC; it’s a supply peg. That means BTC/tBTC might not be exactly the same. tBTC might trade at a slight premium or a discount.
+  - question: Why is TBTC collateralized with ETH at its current ratio?
+    answer: >
+      Because it makes for a safer system, which is very important in DeFi especially at the launch of a new network. ETH is a more safe collateral type because it’s the DeFi standard, and the team working on tBTC has plans to shift the ETH/BTC collateralization ratio from 150% to 135% fairly soon after launch. It is also examining new mechanisms that could bring that ratio down to 40% collateralization later on.
+  - question: Where could something go wrong in the tBTC system?
+    answer: >
+      This technology is new and it’s impossible to anticipate every situation where something could go wrong.  That being said, there are several situations the community has identified and taken careful measures to address. The security model is such that if the signers collude and run off with your Bitcoin deposit, users are paid back in TBTC; that’s what the ETH bonds are for (they’ll be seized and liquidated). If ETH takes a massive dip in a short period of time and ALL signers run off and break the peg at same time, the system falls back to a synthetic. For more information, please look at the <a href="https://docs.keep.network/tbtc/index.pdf" target="_blank">tBTC technical spec</a>.
+  - question: Why are there fixed lot sizes? Why not any random denomination?
+    answer: >
+      Too many lot sizes becomes an issue for liquidity pools. Maintaining several standard lot sizes allows for greater redemption availability.
+  - question: Is there a tBTC widget I can use to directly hook tBTC minting and redeeming into my DeFi dapp?
+    answer: >
+      Not yet. Integration work is required to build tBTC minting and redemption into a dApp. The code is open-sourced in the <a href="https://github.com/keep-network/tbtc.js" target="_blank">tbtc.js GitHub</a>, enabling developers to build interfaces that match their products. To validate Bitcoin transactions, the best approach is to run an electrum server, which is very easy to spin up.
+  - question: Has tBTC been audited?
+    answer: >
+      ConsenSys Diligence is currently completing a six-week cryptography and code audit. The results will be published once they become available.
+  - question: Does Signing for tBTC and staking ETH make you a MSB?
+    answer: >
+      Each user should undertake their own analysis as to whether there are any legal restrictions in their jurisdiction that would either prevent them from using tBTC or require the user to register with certain government entities.
+  - question: Is depositing BTC for tBTC a taxable event?
+    answer: >
+      Please check with a tax professional to determine whether depositing BTC for TBTC is a taxable event in a given jurisdiction. One thing to consider is the NFT associated with the UTXO of a deposit. This NFT is designed to allow a fee to be paid for custody of BTC and to offer the ability to redeem the exact same UTXO within the six month fee period.
+  - question: How is the tBTC signer set non-custodial?
+    answer: >
+      tBTC’s signer sets use threshold ECDSA as a Bitcoin multisig replacement. For every deposit, a new signer set is pulled together (selected by the random beacon), and they generate a Bitcoin PKH address for the depositor, which is marked on the Ethereum chain.
+  - question: Who are the signers? Can anyone become a signer?
+    answer: >
+      Shortly after launch, there should be  a group of roughly 80 private sale KEEP purchasers and a few other trusted parties signing for tBTC. Very soon an opportunity will be announced for more individuals to participate by staking ETH to become a signer.
+  - question: Why is this better than other BTC on Ethereum projects?
+    answer: >
+      Some people believe tBTC is better for several reasons.  Some projects have built synthetic price pegs, which is not a true bridge. Other projects are supply pegs, but have centralized parties adding friction to the minting and redemption process and therefore, are not censorship-resistant systems. Some new bridges are decentralized supply pegs, however, those security models are less safe. They rely on a ⅔ honesty assumption, no ETH/extra collateral to back up deposits, and use brand new “roll your own crypto” rather than peer-reviewed, t-ECDSA cryptography).
+  - question: What does a six-month fee period mean? Can BTC be claimed only after six months?
+    answer: >
+      No, there is no need to return at six months, except if there is a preference to  redeem Bitcoin with a certain UTXO. This is what the NFT receipt, TDT, is for. Most retail DeFi users do not have this consideration, and do not need to return in six months.
+  - question: Are there plans to build a Bitcoin bridge on other chains?
+    answer: >
+      There are no firm plans to build a bridge on other chains. However the <a href="https://www.crosschain.group/" target="_blank">Cross-Chain Group</a> has had early conversations with chains like Cosmos, Zcash, and Polkadot on trustless bridge designs.
+  - question: Does tBTC ownership give you any governance rights?
+    answer: >
+      No.
+  - question: Why not just do a price peg?
+    answer: >
+      The team behind tBTC is building a supply peg, not a price peg. It’s not a synthetic mechanism. For bitcoin holders, it shouldn’t matter what the actual price is, it just matters that you can redeem it for 1 BTC
+  - question: Why does tBTC need a price feed oracle?
+    answer: >
+      tBTC is a sidechain that requires work from anonymous parties, so bonds from those parties must be held to prevent collusion. For now, it is necessary to ensure that signers are bonded in order to protect against misbehavior. A price feed oracle is needed to maintain the BTC/ETH price for this bond.
+---

--- a/src/pages/faq/index.es.md
+++ b/src/pages/faq/index.es.md
@@ -1,0 +1,57 @@
+---
+template: 'faq-page'
+path: /faq
+title: FAQ
+questions:
+  - question: How does tBTC maintain the peg?
+    answer: >
+      tBTC does not maintain the peg. It’s a supply peg not a price peg, so there is no algorithmic mechanism needed to function as a decentralized peg.
+  - question: Why is the TBTC price not exactly the same as BTC?
+    answer: >
+      tBTC is not a price peg to BTC; it’s a supply peg. That means BTC/tBTC might not be exactly the same. tBTC might trade at a slight premium or a discount.
+  - question: Why is TBTC collateralized with ETH at its current ratio?
+    answer: >
+      Because it makes for a safer system, which is very important in DeFi especially at the launch of a new network. ETH is a more safe collateral type because it’s the DeFi standard, and the team working on tBTC has plans to shift the ETH/BTC collateralization ratio from 150% to 135% fairly soon after launch. It is also examining new mechanisms that could bring that ratio down to 40% collateralization later on.
+  - question: Where could something go wrong in the tBTC system?
+    answer: >
+      This technology is new and it’s impossible to anticipate every situation where something could go wrong.  That being said, there are several situations the community has identified and taken careful measures to address. The security model is such that if the signers collude and run off with your Bitcoin deposit, users are paid back in TBTC; that’s what the ETH bonds are for (they’ll be seized and liquidated). If ETH takes a massive dip in a short period of time and ALL signers run off and break the peg at same time, the system falls back to a synthetic. For more information, please look at the <a href="https://docs.keep.network/tbtc/index.pdf" target="_blank">tBTC technical spec</a>.
+  - question: Why are there fixed lot sizes? Why not any random denomination?
+    answer: >
+      Too many lot sizes becomes an issue for liquidity pools. Maintaining several standard lot sizes allows for greater redemption availability.
+  - question: Is there a tBTC widget I can use to directly hook tBTC minting and redeeming into my DeFi dapp?
+    answer: >
+      Not yet. Integration work is required to build tBTC minting and redemption into a dApp. The code is open-sourced in the <a href="https://github.com/keep-network/tbtc.js" target="_blank">tbtc.js GitHub</a>, enabling developers to build interfaces that match their products. To validate Bitcoin transactions, the best approach is to run an electrum server, which is very easy to spin up.
+  - question: Has tBTC been audited?
+    answer: >
+      ConsenSys Diligence is currently completing a six-week cryptography and code audit. The results will be published once they become available.
+  - question: Does Signing for tBTC and staking ETH make you a MSB?
+    answer: >
+      Each user should undertake their own analysis as to whether there are any legal restrictions in their jurisdiction that would either prevent them from using tBTC or require the user to register with certain government entities.
+  - question: Is depositing BTC for tBTC a taxable event?
+    answer: >
+      Please check with a tax professional to determine whether depositing BTC for TBTC is a taxable event in a given jurisdiction. One thing to consider is the NFT associated with the UTXO of a deposit. This NFT is designed to allow a fee to be paid for custody of BTC and to offer the ability to redeem the exact same UTXO within the six month fee period.
+  - question: How is the tBTC signer set non-custodial?
+    answer: >
+      tBTC’s signer sets use threshold ECDSA as a Bitcoin multisig replacement. For every deposit, a new signer set is pulled together (selected by the random beacon), and they generate a Bitcoin PKH address for the depositor, which is marked on the Ethereum chain.
+  - question: Who are the signers? Can anyone become a signer?
+    answer: >
+      Shortly after launch, there should be  a group of roughly 80 private sale KEEP purchasers and a few other trusted parties signing for tBTC. Very soon an opportunity will be announced for more individuals to participate by staking ETH to become a signer.
+  - question: Why is this better than other BTC on Ethereum projects?
+    answer: >
+      Some people believe tBTC is better for several reasons.  Some projects have built synthetic price pegs, which is not a true bridge. Other projects are supply pegs, but have centralized parties adding friction to the minting and redemption process and therefore, are not censorship-resistant systems. Some new bridges are decentralized supply pegs, however, those security models are less safe. They rely on a ⅔ honesty assumption, no ETH/extra collateral to back up deposits, and use brand new “roll your own crypto” rather than peer-reviewed, t-ECDSA cryptography).
+  - question: What does a six-month fee period mean? Can BTC be claimed only after six months?
+    answer: >
+      No, there is no need to return at six months, except if there is a preference to  redeem Bitcoin with a certain UTXO. This is what the NFT receipt, TDT, is for. Most retail DeFi users do not have this consideration, and do not need to return in six months.
+  - question: Are there plans to build a Bitcoin bridge on other chains?
+    answer: >
+      There are no firm plans to build a bridge on other chains. However the <a href="https://www.crosschain.group/" target="_blank">Cross-Chain Group</a> has had early conversations with chains like Cosmos, Zcash, and Polkadot on trustless bridge designs.
+  - question: Does tBTC ownership give you any governance rights?
+    answer: >
+      No.
+  - question: Why not just do a price peg?
+    answer: >
+      The team behind tBTC is building a supply peg, not a price peg. It’s not a synthetic mechanism. For bitcoin holders, it shouldn’t matter what the actual price is, it just matters that you can redeem it for 1 BTC
+  - question: Why does tBTC need a price feed oracle?
+    answer: >
+      tBTC is a sidechain that requires work from anonymous parties, so bonds from those parties must be held to prevent collusion. For now, it is necessary to ensure that signers are bonded in order to protect against misbehavior. A price feed oracle is needed to maintain the BTC/ETH price for this bond.
+---

--- a/src/pages/faq/index.fr.md
+++ b/src/pages/faq/index.fr.md
@@ -1,0 +1,57 @@
+---
+template: 'faq-page'
+path: /faq
+title: FAQ
+questions:
+  - question: How does tBTC maintain the peg?
+    answer: >
+      tBTC does not maintain the peg. It’s a supply peg not a price peg, so there is no algorithmic mechanism needed to function as a decentralized peg.
+  - question: Why is the TBTC price not exactly the same as BTC?
+    answer: >
+      tBTC is not a price peg to BTC; it’s a supply peg. That means BTC/tBTC might not be exactly the same. tBTC might trade at a slight premium or a discount.
+  - question: Why is TBTC collateralized with ETH at its current ratio?
+    answer: >
+      Because it makes for a safer system, which is very important in DeFi especially at the launch of a new network. ETH is a more safe collateral type because it’s the DeFi standard, and the team working on tBTC has plans to shift the ETH/BTC collateralization ratio from 150% to 135% fairly soon after launch. It is also examining new mechanisms that could bring that ratio down to 40% collateralization later on.
+  - question: Where could something go wrong in the tBTC system?
+    answer: >
+      This technology is new and it’s impossible to anticipate every situation where something could go wrong.  That being said, there are several situations the community has identified and taken careful measures to address. The security model is such that if the signers collude and run off with your Bitcoin deposit, users are paid back in TBTC; that’s what the ETH bonds are for (they’ll be seized and liquidated). If ETH takes a massive dip in a short period of time and ALL signers run off and break the peg at same time, the system falls back to a synthetic. For more information, please look at the <a href="https://docs.keep.network/tbtc/index.pdf" target="_blank">tBTC technical spec</a>.
+  - question: Why are there fixed lot sizes? Why not any random denomination?
+    answer: >
+      Too many lot sizes becomes an issue for liquidity pools. Maintaining several standard lot sizes allows for greater redemption availability.
+  - question: Is there a tBTC widget I can use to directly hook tBTC minting and redeeming into my DeFi dapp?
+    answer: >
+      Not yet. Integration work is required to build tBTC minting and redemption into a dApp. The code is open-sourced in the <a href="https://github.com/keep-network/tbtc.js" target="_blank">tbtc.js GitHub</a>, enabling developers to build interfaces that match their products. To validate Bitcoin transactions, the best approach is to run an electrum server, which is very easy to spin up.
+  - question: Has tBTC been audited?
+    answer: >
+      ConsenSys Diligence is currently completing a six-week cryptography and code audit. The results will be published once they become available.
+  - question: Does Signing for tBTC and staking ETH make you a MSB?
+    answer: >
+      Each user should undertake their own analysis as to whether there are any legal restrictions in their jurisdiction that would either prevent them from using tBTC or require the user to register with certain government entities.
+  - question: Is depositing BTC for tBTC a taxable event?
+    answer: >
+      Please check with a tax professional to determine whether depositing BTC for TBTC is a taxable event in a given jurisdiction. One thing to consider is the NFT associated with the UTXO of a deposit. This NFT is designed to allow a fee to be paid for custody of BTC and to offer the ability to redeem the exact same UTXO within the six month fee period.
+  - question: How is the tBTC signer set non-custodial?
+    answer: >
+      tBTC’s signer sets use threshold ECDSA as a Bitcoin multisig replacement. For every deposit, a new signer set is pulled together (selected by the random beacon), and they generate a Bitcoin PKH address for the depositor, which is marked on the Ethereum chain.
+  - question: Who are the signers? Can anyone become a signer?
+    answer: >
+      Shortly after launch, there should be  a group of roughly 80 private sale KEEP purchasers and a few other trusted parties signing for tBTC. Very soon an opportunity will be announced for more individuals to participate by staking ETH to become a signer.
+  - question: Why is this better than other BTC on Ethereum projects?
+    answer: >
+      Some people believe tBTC is better for several reasons.  Some projects have built synthetic price pegs, which is not a true bridge. Other projects are supply pegs, but have centralized parties adding friction to the minting and redemption process and therefore, are not censorship-resistant systems. Some new bridges are decentralized supply pegs, however, those security models are less safe. They rely on a ⅔ honesty assumption, no ETH/extra collateral to back up deposits, and use brand new “roll your own crypto” rather than peer-reviewed, t-ECDSA cryptography).
+  - question: What does a six-month fee period mean? Can BTC be claimed only after six months?
+    answer: >
+      No, there is no need to return at six months, except if there is a preference to  redeem Bitcoin with a certain UTXO. This is what the NFT receipt, TDT, is for. Most retail DeFi users do not have this consideration, and do not need to return in six months.
+  - question: Are there plans to build a Bitcoin bridge on other chains?
+    answer: >
+      There are no firm plans to build a bridge on other chains. However the <a href="https://www.crosschain.group/" target="_blank">Cross-Chain Group</a> has had early conversations with chains like Cosmos, Zcash, and Polkadot on trustless bridge designs.
+  - question: Does tBTC ownership give you any governance rights?
+    answer: >
+      No.
+  - question: Why not just do a price peg?
+    answer: >
+      The team behind tBTC is building a supply peg, not a price peg. It’s not a synthetic mechanism. For bitcoin holders, it shouldn’t matter what the actual price is, it just matters that you can redeem it for 1 BTC
+  - question: Why does tBTC need a price feed oracle?
+    answer: >
+      tBTC is a sidechain that requires work from anonymous parties, so bonds from those parties must be held to prevent collusion. For now, it is necessary to ensure that signers are bonded in order to protect against misbehavior. A price feed oracle is needed to maintain the BTC/ETH price for this bond.
+---

--- a/src/pages/faq/index.pl.md
+++ b/src/pages/faq/index.pl.md
@@ -1,0 +1,57 @@
+---
+template: 'faq-page'
+path: /faq
+title: FAQ
+questions:
+  - question: How does tBTC maintain the peg?
+    answer: >
+      tBTC does not maintain the peg. It’s a supply peg not a price peg, so there is no algorithmic mechanism needed to function as a decentralized peg.
+  - question: Why is the TBTC price not exactly the same as BTC?
+    answer: >
+      tBTC is not a price peg to BTC; it’s a supply peg. That means BTC/tBTC might not be exactly the same. tBTC might trade at a slight premium or a discount.
+  - question: Why is TBTC collateralized with ETH at its current ratio?
+    answer: >
+      Because it makes for a safer system, which is very important in DeFi especially at the launch of a new network. ETH is a more safe collateral type because it’s the DeFi standard, and the team working on tBTC has plans to shift the ETH/BTC collateralization ratio from 150% to 135% fairly soon after launch. It is also examining new mechanisms that could bring that ratio down to 40% collateralization later on.
+  - question: Where could something go wrong in the tBTC system?
+    answer: >
+      This technology is new and it’s impossible to anticipate every situation where something could go wrong.  That being said, there are several situations the community has identified and taken careful measures to address. The security model is such that if the signers collude and run off with your Bitcoin deposit, users are paid back in TBTC; that’s what the ETH bonds are for (they’ll be seized and liquidated). If ETH takes a massive dip in a short period of time and ALL signers run off and break the peg at same time, the system falls back to a synthetic. For more information, please look at the <a href="https://docs.keep.network/tbtc/index.pdf" target="_blank">tBTC technical spec</a>.
+  - question: Why are there fixed lot sizes? Why not any random denomination?
+    answer: >
+      Too many lot sizes becomes an issue for liquidity pools. Maintaining several standard lot sizes allows for greater redemption availability.
+  - question: Is there a tBTC widget I can use to directly hook tBTC minting and redeeming into my DeFi dapp?
+    answer: >
+      Not yet. Integration work is required to build tBTC minting and redemption into a dApp. The code is open-sourced in the <a href="https://github.com/keep-network/tbtc.js" target="_blank">tbtc.js GitHub</a>, enabling developers to build interfaces that match their products. To validate Bitcoin transactions, the best approach is to run an electrum server, which is very easy to spin up.
+  - question: Has tBTC been audited?
+    answer: >
+      ConsenSys Diligence is currently completing a six-week cryptography and code audit. The results will be published once they become available.
+  - question: Does Signing for tBTC and staking ETH make you a MSB?
+    answer: >
+      Each user should undertake their own analysis as to whether there are any legal restrictions in their jurisdiction that would either prevent them from using tBTC or require the user to register with certain government entities.
+  - question: Is depositing BTC for tBTC a taxable event?
+    answer: >
+      Please check with a tax professional to determine whether depositing BTC for TBTC is a taxable event in a given jurisdiction. One thing to consider is the NFT associated with the UTXO of a deposit. This NFT is designed to allow a fee to be paid for custody of BTC and to offer the ability to redeem the exact same UTXO within the six month fee period.
+  - question: How is the tBTC signer set non-custodial?
+    answer: >
+      tBTC’s signer sets use threshold ECDSA as a Bitcoin multisig replacement. For every deposit, a new signer set is pulled together (selected by the random beacon), and they generate a Bitcoin PKH address for the depositor, which is marked on the Ethereum chain.
+  - question: Who are the signers? Can anyone become a signer?
+    answer: >
+      Shortly after launch, there should be  a group of roughly 80 private sale KEEP purchasers and a few other trusted parties signing for tBTC. Very soon an opportunity will be announced for more individuals to participate by staking ETH to become a signer.
+  - question: Why is this better than other BTC on Ethereum projects?
+    answer: >
+      Some people believe tBTC is better for several reasons.  Some projects have built synthetic price pegs, which is not a true bridge. Other projects are supply pegs, but have centralized parties adding friction to the minting and redemption process and therefore, are not censorship-resistant systems. Some new bridges are decentralized supply pegs, however, those security models are less safe. They rely on a ⅔ honesty assumption, no ETH/extra collateral to back up deposits, and use brand new “roll your own crypto” rather than peer-reviewed, t-ECDSA cryptography).
+  - question: What does a six-month fee period mean? Can BTC be claimed only after six months?
+    answer: >
+      No, there is no need to return at six months, except if there is a preference to  redeem Bitcoin with a certain UTXO. This is what the NFT receipt, TDT, is for. Most retail DeFi users do not have this consideration, and do not need to return in six months.
+  - question: Are there plans to build a Bitcoin bridge on other chains?
+    answer: >
+      There are no firm plans to build a bridge on other chains. However the <a href="https://www.crosschain.group/" target="_blank">Cross-Chain Group</a> has had early conversations with chains like Cosmos, Zcash, and Polkadot on trustless bridge designs.
+  - question: Does tBTC ownership give you any governance rights?
+    answer: >
+      No.
+  - question: Why not just do a price peg?
+    answer: >
+      The team behind tBTC is building a supply peg, not a price peg. It’s not a synthetic mechanism. For bitcoin holders, it shouldn’t matter what the actual price is, it just matters that you can redeem it for 1 BTC
+  - question: Why does tBTC need a price feed oracle?
+    answer: >
+      tBTC is a sidechain that requires work from anonymous parties, so bonds from those parties must be held to prevent collusion. For now, it is necessary to ensure that signers are bonded in order to protect against misbehavior. A price feed oracle is needed to maintain the BTC/ETH price for this bond.
+---

--- a/src/pages/faq/index.ru.md
+++ b/src/pages/faq/index.ru.md
@@ -1,0 +1,57 @@
+---
+template: 'faq-page'
+path: /faq
+title: FAQ
+questions:
+  - question: How does tBTC maintain the peg?
+    answer: >
+      tBTC does not maintain the peg. It’s a supply peg not a price peg, so there is no algorithmic mechanism needed to function as a decentralized peg.
+  - question: Why is the TBTC price not exactly the same as BTC?
+    answer: >
+      tBTC is not a price peg to BTC; it’s a supply peg. That means BTC/tBTC might not be exactly the same. tBTC might trade at a slight premium or a discount.
+  - question: Why is TBTC collateralized with ETH at its current ratio?
+    answer: >
+      Because it makes for a safer system, which is very important in DeFi especially at the launch of a new network. ETH is a more safe collateral type because it’s the DeFi standard, and the team working on tBTC has plans to shift the ETH/BTC collateralization ratio from 150% to 135% fairly soon after launch. It is also examining new mechanisms that could bring that ratio down to 40% collateralization later on.
+  - question: Where could something go wrong in the tBTC system?
+    answer: >
+      This technology is new and it’s impossible to anticipate every situation where something could go wrong.  That being said, there are several situations the community has identified and taken careful measures to address. The security model is such that if the signers collude and run off with your Bitcoin deposit, users are paid back in TBTC; that’s what the ETH bonds are for (they’ll be seized and liquidated). If ETH takes a massive dip in a short period of time and ALL signers run off and break the peg at same time, the system falls back to a synthetic. For more information, please look at the <a href="https://docs.keep.network/tbtc/index.pdf" target="_blank">tBTC technical spec</a>.
+  - question: Why are there fixed lot sizes? Why not any random denomination?
+    answer: >
+      Too many lot sizes becomes an issue for liquidity pools. Maintaining several standard lot sizes allows for greater redemption availability.
+  - question: Is there a tBTC widget I can use to directly hook tBTC minting and redeeming into my DeFi dapp?
+    answer: >
+      Not yet. Integration work is required to build tBTC minting and redemption into a dApp. The code is open-sourced in the <a href="https://github.com/keep-network/tbtc.js" target="_blank">tbtc.js GitHub</a>, enabling developers to build interfaces that match their products. To validate Bitcoin transactions, the best approach is to run an electrum server, which is very easy to spin up.
+  - question: Has tBTC been audited?
+    answer: >
+      ConsenSys Diligence is currently completing a six-week cryptography and code audit. The results will be published once they become available.
+  - question: Does Signing for tBTC and staking ETH make you a MSB?
+    answer: >
+      Each user should undertake their own analysis as to whether there are any legal restrictions in their jurisdiction that would either prevent them from using tBTC or require the user to register with certain government entities.
+  - question: Is depositing BTC for tBTC a taxable event?
+    answer: >
+      Please check with a tax professional to determine whether depositing BTC for TBTC is a taxable event in a given jurisdiction. One thing to consider is the NFT associated with the UTXO of a deposit. This NFT is designed to allow a fee to be paid for custody of BTC and to offer the ability to redeem the exact same UTXO within the six month fee period.
+  - question: How is the tBTC signer set non-custodial?
+    answer: >
+      tBTC’s signer sets use threshold ECDSA as a Bitcoin multisig replacement. For every deposit, a new signer set is pulled together (selected by the random beacon), and they generate a Bitcoin PKH address for the depositor, which is marked on the Ethereum chain.
+  - question: Who are the signers? Can anyone become a signer?
+    answer: >
+      Shortly after launch, there should be  a group of roughly 80 private sale KEEP purchasers and a few other trusted parties signing for tBTC. Very soon an opportunity will be announced for more individuals to participate by staking ETH to become a signer.
+  - question: Why is this better than other BTC on Ethereum projects?
+    answer: >
+      Some people believe tBTC is better for several reasons.  Some projects have built synthetic price pegs, which is not a true bridge. Other projects are supply pegs, but have centralized parties adding friction to the minting and redemption process and therefore, are not censorship-resistant systems. Some new bridges are decentralized supply pegs, however, those security models are less safe. They rely on a ⅔ honesty assumption, no ETH/extra collateral to back up deposits, and use brand new “roll your own crypto” rather than peer-reviewed, t-ECDSA cryptography).
+  - question: What does a six-month fee period mean? Can BTC be claimed only after six months?
+    answer: >
+      No, there is no need to return at six months, except if there is a preference to  redeem Bitcoin with a certain UTXO. This is what the NFT receipt, TDT, is for. Most retail DeFi users do not have this consideration, and do not need to return in six months.
+  - question: Are there plans to build a Bitcoin bridge on other chains?
+    answer: >
+      There are no firm plans to build a bridge on other chains. However the <a href="https://www.crosschain.group/" target="_blank">Cross-Chain Group</a> has had early conversations with chains like Cosmos, Zcash, and Polkadot on trustless bridge designs.
+  - question: Does tBTC ownership give you any governance rights?
+    answer: >
+      No.
+  - question: Why not just do a price peg?
+    answer: >
+      The team behind tBTC is building a supply peg, not a price peg. It’s not a synthetic mechanism. For bitcoin holders, it shouldn’t matter what the actual price is, it just matters that you can redeem it for 1 BTC
+  - question: Why does tBTC need a price feed oracle?
+    answer: >
+      tBTC is a sidechain that requires work from anonymous parties, so bonds from those parties must be held to prevent collusion. For now, it is necessary to ensure that signers are bonded in order to protect against misbehavior. A price feed oracle is needed to maintain the BTC/ETH price for this bond.
+---

--- a/src/pages/index.de.md
+++ b/src/pages/index.de.md
@@ -1,0 +1,76 @@
+---
+template: home-page
+path: /
+title: Home
+hero:
+  buttons:
+    - text: Get Email Updates
+      url: '/#mailing-list'
+    - text: Start Building
+      url: /developers
+  subtitle: Deposit and redeem BTC in DeFi without intermediaries.
+  title: The safe way to earn with your Bitcoin.
+features:
+  - description: 'Every TBTC is backed 1:1 with BTC'
+    title: Backed
+  - description: No intermediaries - Redeem TBTC for BTC at any time
+    title: Permissionless
+  - description: Audited and open-source
+    title: Secure
+  - description: 3 steps to convert from BTC to TBTC and back
+    title: Simple
+spotlight_1:
+  body: >-
+    tBTC will begin moving toward full mainnet launch over the coming weeks.
+    Launch will occur over a series of milestones starting April 24th.
+  button:
+    text: Read more
+    url: 'https://tbtc.network/news/2020-04-24-tbtc-launch-key-dates/'
+  label: Announcement
+  title: 'tBTC Launch: Key Dates'
+spotlight_2:
+  button:
+    text: Developer Toolkit
+    url: /developers
+  label: Developers
+  title: Integrate TBTC to add Bitcoin to your dApp
+integrations_section:
+  integrations:
+    - logo:
+        alt: Compound Logo
+        image: /img/compound.png
+      name: Compound
+      url: 'https://compound.finance/'
+    - logo:
+        alt: Bison Trails
+        image: /img/BisonTrails.png
+      name: Bison Trails
+      url: 'https://bisontrails.co/'
+    - logo:
+        alt: Uniswap Logo
+        image: /img/uniswap.png
+      name: Uniswap
+      url: 'https://uniswap.org/'
+    - logo:
+        alt: Kyber Logo
+        image: /img/kyber.png
+      name: Kyber Network
+      url: 'https://kyber.network/'
+    - logo:
+        alt: Loopring Logo
+        image: /img/loopring.png
+      name: Loopring
+      url: 'https://loopring.org/'
+    - logo:
+        alt: 1inch Logo
+        image: /img/1inch.png
+      name: 1inch
+      url: 'https://1inch.exchange/'
+    - logo:
+        alt: Radar Logo
+        image: /img/relay.png
+      name: Radar Relay
+      url: 'https://radarrelay.com/'
+  title: Integrations
+---
+

--- a/src/pages/index.es.md
+++ b/src/pages/index.es.md
@@ -1,0 +1,76 @@
+---
+template: home-page
+path: /
+title: Home
+hero:
+  buttons:
+    - text: Get Email Updates
+      url: '/#mailing-list'
+    - text: Start Building
+      url: /developers
+  subtitle: Deposit and redeem BTC in DeFi without intermediaries.
+  title: The safe way to earn with your Bitcoin.
+features:
+  - description: 'Every TBTC is backed 1:1 with BTC'
+    title: Backed
+  - description: No intermediaries - Redeem TBTC for BTC at any time
+    title: Permissionless
+  - description: Audited and open-source
+    title: Secure
+  - description: 3 steps to convert from BTC to TBTC and back
+    title: Simple
+spotlight_1:
+  body: >-
+    tBTC will begin moving toward full mainnet launch over the coming weeks.
+    Launch will occur over a series of milestones starting April 24th.
+  button:
+    text: Read more
+    url: 'https://tbtc.network/news/2020-04-24-tbtc-launch-key-dates/'
+  label: Announcement
+  title: 'tBTC Launch: Key Dates'
+spotlight_2:
+  button:
+    text: Developer Toolkit
+    url: /developers
+  label: Developers
+  title: Integrate TBTC to add Bitcoin to your dApp
+integrations_section:
+  integrations:
+    - logo:
+        alt: Compound Logo
+        image: /img/compound.png
+      name: Compound
+      url: 'https://compound.finance/'
+    - logo:
+        alt: Bison Trails
+        image: /img/BisonTrails.png
+      name: Bison Trails
+      url: 'https://bisontrails.co/'
+    - logo:
+        alt: Uniswap Logo
+        image: /img/uniswap.png
+      name: Uniswap
+      url: 'https://uniswap.org/'
+    - logo:
+        alt: Kyber Logo
+        image: /img/kyber.png
+      name: Kyber Network
+      url: 'https://kyber.network/'
+    - logo:
+        alt: Loopring Logo
+        image: /img/loopring.png
+      name: Loopring
+      url: 'https://loopring.org/'
+    - logo:
+        alt: 1inch Logo
+        image: /img/1inch.png
+      name: 1inch
+      url: 'https://1inch.exchange/'
+    - logo:
+        alt: Radar Logo
+        image: /img/relay.png
+      name: Radar Relay
+      url: 'https://radarrelay.com/'
+  title: Integrations
+---
+

--- a/src/pages/index.fr.md
+++ b/src/pages/index.fr.md
@@ -1,0 +1,76 @@
+---
+template: home-page
+path: /
+title: Home
+hero:
+  buttons:
+    - text: Get Email Updates
+      url: '/#mailing-list'
+    - text: Start Building
+      url: /developers
+  subtitle: Deposit and redeem BTC in DeFi without intermediaries.
+  title: The safe way to earn with your Bitcoin.
+features:
+  - description: 'Every TBTC is backed 1:1 with BTC'
+    title: Backed
+  - description: No intermediaries - Redeem TBTC for BTC at any time
+    title: Permissionless
+  - description: Audited and open-source
+    title: Secure
+  - description: 3 steps to convert from BTC to TBTC and back
+    title: Simple
+spotlight_1:
+  body: >-
+    tBTC will begin moving toward full mainnet launch over the coming weeks.
+    Launch will occur over a series of milestones starting April 24th.
+  button:
+    text: Read more
+    url: 'https://tbtc.network/news/2020-04-24-tbtc-launch-key-dates/'
+  label: Announcement
+  title: 'tBTC Launch: Key Dates'
+spotlight_2:
+  button:
+    text: Developer Toolkit
+    url: /developers
+  label: Developers
+  title: Integrate TBTC to add Bitcoin to your dApp
+integrations_section:
+  integrations:
+    - logo:
+        alt: Compound Logo
+        image: /img/compound.png
+      name: Compound
+      url: 'https://compound.finance/'
+    - logo:
+        alt: Bison Trails
+        image: /img/BisonTrails.png
+      name: Bison Trails
+      url: 'https://bisontrails.co/'
+    - logo:
+        alt: Uniswap Logo
+        image: /img/uniswap.png
+      name: Uniswap
+      url: 'https://uniswap.org/'
+    - logo:
+        alt: Kyber Logo
+        image: /img/kyber.png
+      name: Kyber Network
+      url: 'https://kyber.network/'
+    - logo:
+        alt: Loopring Logo
+        image: /img/loopring.png
+      name: Loopring
+      url: 'https://loopring.org/'
+    - logo:
+        alt: 1inch Logo
+        image: /img/1inch.png
+      name: 1inch
+      url: 'https://1inch.exchange/'
+    - logo:
+        alt: Radar Logo
+        image: /img/relay.png
+      name: Radar Relay
+      url: 'https://radarrelay.com/'
+  title: Integrations
+---
+

--- a/src/pages/index.pl.md
+++ b/src/pages/index.pl.md
@@ -1,0 +1,76 @@
+---
+template: home-page
+path: /
+title: Home
+hero:
+  buttons:
+    - text: Get Email Updates
+      url: '/#mailing-list'
+    - text: Start Building
+      url: /developers
+  subtitle: Deposit and redeem BTC in DeFi without intermediaries.
+  title: The safe way to earn with your Bitcoin.
+features:
+  - description: 'Every TBTC is backed 1:1 with BTC'
+    title: Backed
+  - description: No intermediaries - Redeem TBTC for BTC at any time
+    title: Permissionless
+  - description: Audited and open-source
+    title: Secure
+  - description: 3 steps to convert from BTC to TBTC and back
+    title: Simple
+spotlight_1:
+  body: >-
+    tBTC will begin moving toward full mainnet launch over the coming weeks.
+    Launch will occur over a series of milestones starting April 24th.
+  button:
+    text: Read more
+    url: 'https://tbtc.network/news/2020-04-24-tbtc-launch-key-dates/'
+  label: Announcement
+  title: 'tBTC Launch: Key Dates'
+spotlight_2:
+  button:
+    text: Developer Toolkit
+    url: /developers
+  label: Developers
+  title: Integrate TBTC to add Bitcoin to your dApp
+integrations_section:
+  integrations:
+    - logo:
+        alt: Compound Logo
+        image: /img/compound.png
+      name: Compound
+      url: 'https://compound.finance/'
+    - logo:
+        alt: Bison Trails
+        image: /img/BisonTrails.png
+      name: Bison Trails
+      url: 'https://bisontrails.co/'
+    - logo:
+        alt: Uniswap Logo
+        image: /img/uniswap.png
+      name: Uniswap
+      url: 'https://uniswap.org/'
+    - logo:
+        alt: Kyber Logo
+        image: /img/kyber.png
+      name: Kyber Network
+      url: 'https://kyber.network/'
+    - logo:
+        alt: Loopring Logo
+        image: /img/loopring.png
+      name: Loopring
+      url: 'https://loopring.org/'
+    - logo:
+        alt: 1inch Logo
+        image: /img/1inch.png
+      name: 1inch
+      url: 'https://1inch.exchange/'
+    - logo:
+        alt: Radar Logo
+        image: /img/relay.png
+      name: Radar Relay
+      url: 'https://radarrelay.com/'
+  title: Integrations
+---
+

--- a/src/pages/index.ru.md
+++ b/src/pages/index.ru.md
@@ -1,0 +1,76 @@
+---
+template: home-page
+path: /
+title: Home
+hero:
+  buttons:
+    - text: Get Email Updates
+      url: '/#mailing-list'
+    - text: Start Building
+      url: /developers
+  subtitle: Deposit and redeem BTC in DeFi without intermediaries.
+  title: The safe way to earn with your Bitcoin.
+features:
+  - description: 'Every TBTC is backed 1:1 with BTC'
+    title: Backed
+  - description: No intermediaries - Redeem TBTC for BTC at any time
+    title: Permissionless
+  - description: Audited and open-source
+    title: Secure
+  - description: 3 steps to convert from BTC to TBTC and back
+    title: Simple
+spotlight_1:
+  body: >-
+    tBTC will begin moving toward full mainnet launch over the coming weeks.
+    Launch will occur over a series of milestones starting April 24th.
+  button:
+    text: Read more
+    url: 'https://tbtc.network/news/2020-04-24-tbtc-launch-key-dates/'
+  label: Announcement
+  title: 'tBTC Launch: Key Dates'
+spotlight_2:
+  button:
+    text: Developer Toolkit
+    url: /developers
+  label: Developers
+  title: Integrate TBTC to add Bitcoin to your dApp
+integrations_section:
+  integrations:
+    - logo:
+        alt: Compound Logo
+        image: /img/compound.png
+      name: Compound
+      url: 'https://compound.finance/'
+    - logo:
+        alt: Bison Trails
+        image: /img/BisonTrails.png
+      name: Bison Trails
+      url: 'https://bisontrails.co/'
+    - logo:
+        alt: Uniswap Logo
+        image: /img/uniswap.png
+      name: Uniswap
+      url: 'https://uniswap.org/'
+    - logo:
+        alt: Kyber Logo
+        image: /img/kyber.png
+      name: Kyber Network
+      url: 'https://kyber.network/'
+    - logo:
+        alt: Loopring Logo
+        image: /img/loopring.png
+      name: Loopring
+      url: 'https://loopring.org/'
+    - logo:
+        alt: 1inch Logo
+        image: /img/1inch.png
+      name: 1inch
+      url: 'https://1inch.exchange/'
+    - logo:
+        alt: Radar Logo
+        image: /img/relay.png
+      name: Radar Relay
+      url: 'https://radarrelay.com/'
+  title: Integrations
+---
+

--- a/src/pages/news/index.de.md
+++ b/src/pages/news/index.de.md
@@ -1,0 +1,5 @@
+---
+template: 'news-index'
+path: /news
+title: Nachrichten
+---

--- a/src/pages/news/index.es.md
+++ b/src/pages/news/index.es.md
@@ -1,0 +1,5 @@
+---
+template: 'news-index'
+path: /news
+title: News
+---

--- a/src/pages/news/index.fr.md
+++ b/src/pages/news/index.fr.md
@@ -1,0 +1,5 @@
+---
+template: 'news-index'
+path: /news
+title: News
+---

--- a/src/pages/news/index.md
+++ b/src/pages/news/index.md
@@ -1,4 +1,5 @@
 ---
 template: 'news-index'
 path: /news
+title: News
 ---

--- a/src/pages/news/index.pl.md
+++ b/src/pages/news/index.pl.md
@@ -1,0 +1,5 @@
+---
+template: 'news-index'
+path: /news
+title: News
+---

--- a/src/pages/news/index.ru.md
+++ b/src/pages/news/index.ru.md
@@ -1,0 +1,5 @@
+---
+template: 'news-index'
+path: /news
+title: News
+---

--- a/src/pages/privacy-policy/index.de.md
+++ b/src/pages/privacy-policy/index.de.md
@@ -1,0 +1,156 @@
+---
+template: 'legal-page'
+path: /privacy-policy
+title: Privacy Policy
+---
+Effective and last modified: January 1, 2020
+
+At Keep SECZ, we respect your privacy and are committed to protecting it.
+
+This notice covers all personal information collected in the use of this website, as well as any other websites, applications, or connected products on which it is posted. If in any case our privacy practices differ from those explained in this policy, we will let you know you at the time we ask for or collect your information.
+
+Some pages on our websites may contain links to third-party websites. We do not endorse and have no control over the privacy practices or content of such websites. We recommend you carefully read the privacy policy of each site you visit – including ours.
+
+## 1. We cover a lot of ground in this privacy policy. Use the links below to navigate to later sections of the privacy policy of interest to you.
+- _[The Controller](#Controller)_
+- _[What information we collect about you](#WhatInfoWeCollect)_
+- _[Children&#39;s Online Privacy](#ChildrensOnlinePrivacy)_
+- _[How we collect personal information about you](#HowWeCollectInfo)_
+- _[Cookies and automatic data collection technologies](#CookiesAndAutoDataCollection)_
+- _[How we use your personal information](#HowWeUseYourInfo)_
+- _[Disclosure of Your Information](#DisclosureOfYourInfo)_
+- _[Third Party Content](#ThirdPartyContent)_
+- _[Your Rights and Choices](#YourRightsAndChoices)_
+- _[Data Security](#DataSecurity)_
+- _[Your California Privacy Rights](#YourCaliforniaPrivacyRights)_
+- _[Changes to Our Privacy Policy](#ChangesToOurPrivacyPolicy)_
+- _[Contact Us](#ContactUs)_
+
+## 2. Controller <a id="Controller"></a>
+
+Keep SECZ (collectively referred to as &quot;COMPANY&quot;, &quot;we&quot;, &quot;us&quot; or &quot;our&quot;) in this privacy policy is the controller and responsible for your personal data. We have appointed a data privacy manager who is responsible for overseeing questions in relation to this privacy policy. If you have any questions about this privacy policy, including any requests to exercise your legal rights, please contact the data privacy manager using the details set forth below.
+
+## 3. What information we collect <a id="WhatInfoWeCollect"></a>
+
+Personal information, or personal data, means any information about an individual from which that person can be identified. It does not include data where the identity has been removed (anonymous data), which we can use for any purpose. Some jurisdictions may consider your Ethereum wallet address to be personal data. We may collect, use, store and transfer different kinds of personal information about you which we have grouped together as follows:
+
+- **Identity or Contact Data** includes your email address or similar identifiers or contact information.
+- **Financial information** may include your Ethereum wallet address.
+- **Usage Data** includes information about how you use our websites and our products and services.
+- **Marketing and Communications Data** includes your preferences in receiving marketing from us and your communication preferences.
+
+We may also collect, use and share Aggregated Data such as statistical or demographic data for any purpose. Aggregated Data could be derived from your personal data but is not considered personal data in law as this data will not directly or indirectly reveal your identity. For example, we may aggregate your Usage Data to calculate the percentage of users accessing a specific Network feature. However, if we combine or connect Aggregated Data with your personal data so that it can directly or indirectly identify you, we treat the combined data as personal data which will be used in accordance with this privacy policy.
+
+We do not collect any Special Categories of Personal Data about you (this includes details about your race or ethnicity, religious or philosophical beliefs, sex life, sexual orientation, political opinions, trade union membership, information about your health, and genetic and biometric data). Nor do we collect any information about criminal convictions and offences.
+
+We do not retain information about your transaction history, but you acknowledge that the smart contract transactions facilitated by the Network are recorded in perpetuity on the Ethereum blockchain and cannot be reversed or erased. By using the Network and its smart contracts, you acknowledge that the posting of information concerning your Ethereum wallet address is a function of the smart contract functionality to which you agree.
+
+## 4. Children&#39;s data <a id="ChildrensOnlinePrivacy"></a>
+
+We do not direct our websites to minors, and we do not knowingly collect personal information from children under 18. If you are under 18, do not use or provide any information on this website. If we learn we have collected or received personal information from a child under 18 without verification of parental consent, we will delete that information. If you believe we might have any information from or about a child under 18 please contact us using our Contact Us page.
+
+## 5. How we collect your information <a id="HowWeCollectInfo"></a>
+
+We use different methods to collect information from and about you including through:
+
+- **Direct interactions.** You may give us information about you by interacting with our smart contracts or by communicating with us e-mail, or otherwise. This includes information you provide when you use our Network, subscribe to one of our newsletters or other communications, join a user group, complete a survey, or when you contact us about one of our products, or services.
+- **Third parties or publicly available sources.** We may receive information about you from third parties including, for example, our affiliated companies, business partners, sub-contractors, analytics providers, and service providers.
+- **Technical Data from the following parties:**
+  - Analytics providers such as Crowdcast.
+
+## 6. Cookies and automatic data collection technologies <a id="CookiesAndAutoDataCollection"></a>
+
+Our websites may use automatic data collection technologies to distinguish you from other website users. This helps us deliver a better and more personalized service when you browse our website. It also allows us to improve our websites by enabling us to:
+
+- Estimate our audience size and usage patterns.
+- Store your preferences so we may customize our websites according to your individual interests.
+- Recognize you when you return to our website.
+
+The technologies we use for this automatic data collection may include:
+
+- **Cookies (or browser cookies).**A cookie is a small file placed on the hard drive of your computer. For information about managing browser settings to refuse cookies, see _[Your Rights and Choices](#YourCaliforniaPrivacyRights)_.
+
+We do not respond to or honor &quot;do not track&quot; (a/k/a DNT) signals or similar mechanisms transmitted by web browsers.
+
+## 7. How we use your personal information <a id="HowWeUseYourInfo"></a>
+
+If you provide personal information through the features on our website, we will only use your personal information as the law allows. Examples the activities for which we may collect information, the type of data we collect, and our lawful basis for collecting that data are listed below.
+
+| **Purpose/Activity** | **Type of data** | **Lawful basis for processing including basis of legitimate interest** |
+| --- | --- | --- |
+| To register you for our newsletter | (a) Contact | Performance of a contract with you |
+| To process your smart contract transactions | (a) Wallet address<br/>(b) Contact | (a) Performance of a contract with you<br/>(b) Necessary for our legitimate interests (to collect our fees) |
+| To manage our relationship with you which will include:<br/>(a) Notifying you about changes to our terms or privacy policy<br/>(b) Asking you to leave a review or take a survey | (a) Contact<br/>(b) Profile<br/>(c) Marketing and Communications | (a) Performance of a contract with you<br/>(b) Necessary to comply with a legal obligation<br/>(c) Necessary for our legitimate interests (to keep our records updated and to study how customers use our products/services) |
+| To administer and protect our business and this website (including troubleshooting, data analysis, testing, system maintenance, support, reporting and hosting of data) | (a) Contact<br/>(b) Technical | (a) Necessary for our legitimate interests (for running our business, provision of administration and IT services, network security, to prevent fraud and in the context of a business reorganisation or group restructuring exercise)<br/>(b) Necessary to comply with a legal obligation |
+| To use data analytics to improve our website, products/services, marketing,customer relationships and experiences | (a) Technical<br/>(b) Usage | Necessary for our legitimate interests (to define types of customers for our products and services, to keep our website updated and relevant, to develop our business and to inform our marketing strategy) |
+| To make suggestions and recommendations to you about goods or services that may be of interest to you | (a) Contact<br/>(b) Technical<br/>(c) Usage<br/>(d) Profile<br/>(e) Marketing and Communications | Necessary for our legitimate interests (to develop our products/services and grow our business) |
+
+- To carry out our obligations and enforce our rights.
+- In any other way we may describe when you provide the information.
+- For any other purpose with your consent.
+
+We may use information that is not personal information for any purpose. For example, we may aggregate usage data from many people in a way that does not identify any individuals to calculate the percentage of users accessing a feature on the website.
+
+## 8. Disclosure of Your Information <a id="DisclosureOfYourInfo"></a>
+
+We may share non-personal information without restriction. We may share your personal information with:
+
+- Any member of our corporate group, which means our subsidiaries, affiliates, our ultimate holding company and its subsidiaries, and affiliates.
+- To contractors, service providers, and other third parties we use to support our business.
+- If we offer a co-branded promotion, to our co-sponsor.
+- To fulfill the purpose for which you provide it.
+- For any other purposes that we disclose when you provide the information.
+- With your consent.
+
+We may also disclose your personal information:
+
+- To comply with any court order, law, or legal process, including responding to any government or regulatory request.
+- To enforce Terms of Use and other agreements including for billing and collections purposes.
+- To protect the rights, property, or safety of our business, our employees, our customers, or others. This includes exchanging information with other companies and organizations for the purposes of cybersecurity, fraud protection and credit risk reduction.
+- To investigate suspected violations of any law, rule or regulation, or the terms or policies for our website.
+
+## 9. Third Party Links <a id="ThirdPartyContent"></a>
+
+Some content or applications on our websites may be served by third parties, content providers and application providers including the following:
+
+  1. **Plugins.** Our website may make available the option for you to use &quot;plugins&quot; that are operated by social media companies. If you choose to use one of these plugins, then it may collect information about you and send it back to the social media company that owns it. This may happen even if you do not click on the plugin, if you are logged into the social media website that owns the plugin when you visit our website. Information collected by a plugin is subject to the privacy policy and terms of the social media company that makes it. If you do not want the social media company who owns a plugin to collect information about you when you visit our websites, sign out of the social media network before visiting. By interacting with a plugin when you are on our websites (for example, clicking the Facebook &quot;Like&quot; button), you are intentionally transferring information to that social media company. Further, if you are logged into a social media website when you visit our websites, then you are directing us to share your data with the social media company that owns the plugin.
+  2. **User Content.** Our websites may allow you to upload your own content to public areas of the website. Any information you submit becomes public information, and we do not control how others may use the content you submit. We are not responsible for uses that may violate our privacy policy, the law, or your intellectual property rights.
+  3. **Third-party links.** Our websites may contain links to other sites, which we do not control. Those websites have their own privacy policies and terms, and we encourage you to read those terms before interacting with third-party sites.
+
+## 10. Your Rights and Choices <a id="YourRightsAndChoices"></a>
+
+Your rights may vary depending on where you are located. We have created mechanisms to provide you with the following control over your information.
+
+- **Marketing**. If you do not want us to use your email address or other contact information to promote or recommend our own products and services, or third parties&#39; products or services, you can opt-out by checking the relevant box located on the form where we collect your contact information or, if presented with the option to opt-in, do not opt-in. You may also opt-out of further marketing communications by replying to any promotional email we have sent you or following the opt-out links on that message.
+- **Accessing, Updating and Deleting Your Information.** You can contact us as set forth in the _[Contact Us](#ContactUs)_ section below to request access to, correction of, or deletion of personal information that you have provided to us. We may not accommodate a request to change information if we believe the change would violate any law or legal requirement or negatively affect the information&#39;s accuracy. We cannot delete personal information, if any, that has been posted to the Ethereum blockchain through your use of a smart contract on our Network.
+- **Cookies and Automatic Data Collection Technologies**. You can set your browser to refuse all or some browser cookies, or to alert you when websites set or access cookies. However, if you disable or refuse cookies, please note that some parts of this website may become inaccessible or not function properly.
+- **California Residents**. If you are a California resident, you may have additional personal rights and choices with regard to your personal information. Please see _[Your California Privacy Rights](#YourCAPrivacyRights)_ for more information. California&#39;s &quot;Shine the Light&quot; law (Civil Code Section § 1798.83) permits users of our website that are California residents to request certain information regarding our disclosure of personal information to third parties for their direct marketing purposes. At this time, we do not engage in this type of disclosure.
+- **EU Residents.** If you are a resident of the European Union, you have the right to:
+  - request access to your personal data, commonly known as a &quot;data subject access request&quot;, which allows you to receive a copy of the personal data we hold about you and to check that we are lawfully processing it.
+  - Request a correction of the personal data that we hold about you. This enables you to have any incomplete or inaccurate data we hold about you corrected, though we may need to verify the accuracy of the new data you provide to us. You acknowledge we cannot correct data that has been posted to a public blockchain.
+  - Request erasure of your personal data. This enables you to ask us to delete or remove personal data where there is no good reason for us continuing to process it. You also have the right to ask us to delete or remove your personal data where you have successfully exercised your right to object to processing (see below), where we may have processed your information unlawfully or where we are required to erase your personal data to comply with local law. Note, however, that we may not always be able to comply with your request of erasure for specific legal reasons which will be notified to you, if applicable, at the time of your request. We cannot delete personal data that has been posted to a public blockchain.
+  - Object to processing of your personal data where we are relying on a legitimate interest (or those of a third party) and there is something about your particular situation which makes you want to object to processing on this ground as you feel it impacts on your fundamental rights and freedoms. In some cases, we may demonstrate that we have compelling legitimate grounds to process your information which override your rights and freedoms.
+  - Request restriction of processing of your personal data. This enables you to ask us to suspend the processing of your personal data in the following scenarios:
+    - If you want us to establish the data&#39;s accuracy.
+    - Where you need us to hold the data even if we no longer require it as you need it to establish, exercise or defend legal claims.
+    - You have objected to our use of your data but we need to verify whether we have overriding legitimate grounds to use it.
+  - Request the transfer of your personal data to you or to a third party. We will provide to you, or a third party you have chosen, your personal data in a structured, commonly used, machine-readable format. Note that this right only applies to automated information which you initially provided consent for us to use or where we used the information to perform a contract with you.
+  - Withdraw consent at any time where we are relying on consent to process your personal data. However, this will not affect the lawfulness of any processing carried out before you withdraw your consent. If you withdraw your consent, we may not be able to provide certain products or services to you. We will advise you if this is the case at the time you withdraw your consent. You acknowledge you cannot withdraw consent from participating in a smart contract that has already been executed.
+
+## 11. Data Security <a id="DataSecurity"></a>
+
+The security of your personal information is very important to us. We use physical, electronic, and administrative safeguards designed to protect your personal information from loss, misuse and unauthorized access, use, alteration or disclosure. We will only retain your personal information for as long as reasonably necessary to fulfil the purpose of collecting it.
+
+The safety and security of your information also depends on you. You are responsible for keeping your wallet address and your personal information confidential. We ask you not to share your wallet&#39;s private key with anyone. We urge you to take care when providing information to social media accounts or message boards, which any website visitor can view.
+
+## 12. Your California Privacy Rights <a id="YourCaliforniaPrivacyRights"></a>
+
+If you are a California resident, California law may provide you with additional rights regarding our use of your personal information. To learn more about your California privacy rights, you can view our [Privacy Notice for California Residents](/california-privacy-notice).
+
+## 13. Changes to Our Privacy Policy <a id="ChangesToOurPrivacyPolicy"></a>
+
+We will post any changes we may make to our privacy policy on this page. If the changes materially alter how we use or treat your information we will notify you through a notice on the website home page. The date the privacy policy was last revised is identified at the top of the page.
+
+## 14. Contact Us <a id="ContactUs"></a>
+
+If you have any comments or questions about our privacy policy, please contact our data privacy manager at [legal@keep.network](mailto:legal@keep.network).

--- a/src/pages/privacy-policy/index.es.md
+++ b/src/pages/privacy-policy/index.es.md
@@ -1,0 +1,156 @@
+---
+template: 'legal-page'
+path: /privacy-policy
+title: Privacy Policy
+---
+Effective and last modified: January 1, 2020
+
+At Keep SECZ, we respect your privacy and are committed to protecting it.
+
+This notice covers all personal information collected in the use of this website, as well as any other websites, applications, or connected products on which it is posted. If in any case our privacy practices differ from those explained in this policy, we will let you know you at the time we ask for or collect your information.
+
+Some pages on our websites may contain links to third-party websites. We do not endorse and have no control over the privacy practices or content of such websites. We recommend you carefully read the privacy policy of each site you visit – including ours.
+
+## 1. We cover a lot of ground in this privacy policy. Use the links below to navigate to later sections of the privacy policy of interest to you.
+- _[The Controller](#Controller)_
+- _[What information we collect about you](#WhatInfoWeCollect)_
+- _[Children&#39;s Online Privacy](#ChildrensOnlinePrivacy)_
+- _[How we collect personal information about you](#HowWeCollectInfo)_
+- _[Cookies and automatic data collection technologies](#CookiesAndAutoDataCollection)_
+- _[How we use your personal information](#HowWeUseYourInfo)_
+- _[Disclosure of Your Information](#DisclosureOfYourInfo)_
+- _[Third Party Content](#ThirdPartyContent)_
+- _[Your Rights and Choices](#YourRightsAndChoices)_
+- _[Data Security](#DataSecurity)_
+- _[Your California Privacy Rights](#YourCaliforniaPrivacyRights)_
+- _[Changes to Our Privacy Policy](#ChangesToOurPrivacyPolicy)_
+- _[Contact Us](#ContactUs)_
+
+## 2. Controller <a id="Controller"></a>
+
+Keep SECZ (collectively referred to as &quot;COMPANY&quot;, &quot;we&quot;, &quot;us&quot; or &quot;our&quot;) in this privacy policy is the controller and responsible for your personal data. We have appointed a data privacy manager who is responsible for overseeing questions in relation to this privacy policy. If you have any questions about this privacy policy, including any requests to exercise your legal rights, please contact the data privacy manager using the details set forth below.
+
+## 3. What information we collect <a id="WhatInfoWeCollect"></a>
+
+Personal information, or personal data, means any information about an individual from which that person can be identified. It does not include data where the identity has been removed (anonymous data), which we can use for any purpose. Some jurisdictions may consider your Ethereum wallet address to be personal data. We may collect, use, store and transfer different kinds of personal information about you which we have grouped together as follows:
+
+- **Identity or Contact Data** includes your email address or similar identifiers or contact information.
+- **Financial information** may include your Ethereum wallet address.
+- **Usage Data** includes information about how you use our websites and our products and services.
+- **Marketing and Communications Data** includes your preferences in receiving marketing from us and your communication preferences.
+
+We may also collect, use and share Aggregated Data such as statistical or demographic data for any purpose. Aggregated Data could be derived from your personal data but is not considered personal data in law as this data will not directly or indirectly reveal your identity. For example, we may aggregate your Usage Data to calculate the percentage of users accessing a specific Network feature. However, if we combine or connect Aggregated Data with your personal data so that it can directly or indirectly identify you, we treat the combined data as personal data which will be used in accordance with this privacy policy.
+
+We do not collect any Special Categories of Personal Data about you (this includes details about your race or ethnicity, religious or philosophical beliefs, sex life, sexual orientation, political opinions, trade union membership, information about your health, and genetic and biometric data). Nor do we collect any information about criminal convictions and offences.
+
+We do not retain information about your transaction history, but you acknowledge that the smart contract transactions facilitated by the Network are recorded in perpetuity on the Ethereum blockchain and cannot be reversed or erased. By using the Network and its smart contracts, you acknowledge that the posting of information concerning your Ethereum wallet address is a function of the smart contract functionality to which you agree.
+
+## 4. Children&#39;s data <a id="ChildrensOnlinePrivacy"></a>
+
+We do not direct our websites to minors, and we do not knowingly collect personal information from children under 18. If you are under 18, do not use or provide any information on this website. If we learn we have collected or received personal information from a child under 18 without verification of parental consent, we will delete that information. If you believe we might have any information from or about a child under 18 please contact us using our Contact Us page.
+
+## 5. How we collect your information <a id="HowWeCollectInfo"></a>
+
+We use different methods to collect information from and about you including through:
+
+- **Direct interactions.** You may give us information about you by interacting with our smart contracts or by communicating with us e-mail, or otherwise. This includes information you provide when you use our Network, subscribe to one of our newsletters or other communications, join a user group, complete a survey, or when you contact us about one of our products, or services.
+- **Third parties or publicly available sources.** We may receive information about you from third parties including, for example, our affiliated companies, business partners, sub-contractors, analytics providers, and service providers.
+- **Technical Data from the following parties:**
+  - Analytics providers such as Crowdcast.
+
+## 6. Cookies and automatic data collection technologies <a id="CookiesAndAutoDataCollection"></a>
+
+Our websites may use automatic data collection technologies to distinguish you from other website users. This helps us deliver a better and more personalized service when you browse our website. It also allows us to improve our websites by enabling us to:
+
+- Estimate our audience size and usage patterns.
+- Store your preferences so we may customize our websites according to your individual interests.
+- Recognize you when you return to our website.
+
+The technologies we use for this automatic data collection may include:
+
+- **Cookies (or browser cookies).**A cookie is a small file placed on the hard drive of your computer. For information about managing browser settings to refuse cookies, see _[Your Rights and Choices](#YourCaliforniaPrivacyRights)_.
+
+We do not respond to or honor &quot;do not track&quot; (a/k/a DNT) signals or similar mechanisms transmitted by web browsers.
+
+## 7. How we use your personal information <a id="HowWeUseYourInfo"></a>
+
+If you provide personal information through the features on our website, we will only use your personal information as the law allows. Examples the activities for which we may collect information, the type of data we collect, and our lawful basis for collecting that data are listed below.
+
+| **Purpose/Activity** | **Type of data** | **Lawful basis for processing including basis of legitimate interest** |
+| --- | --- | --- |
+| To register you for our newsletter | (a) Contact | Performance of a contract with you |
+| To process your smart contract transactions | (a) Wallet address<br/>(b) Contact | (a) Performance of a contract with you<br/>(b) Necessary for our legitimate interests (to collect our fees) |
+| To manage our relationship with you which will include:<br/>(a) Notifying you about changes to our terms or privacy policy<br/>(b) Asking you to leave a review or take a survey | (a) Contact<br/>(b) Profile<br/>(c) Marketing and Communications | (a) Performance of a contract with you<br/>(b) Necessary to comply with a legal obligation<br/>(c) Necessary for our legitimate interests (to keep our records updated and to study how customers use our products/services) |
+| To administer and protect our business and this website (including troubleshooting, data analysis, testing, system maintenance, support, reporting and hosting of data) | (a) Contact<br/>(b) Technical | (a) Necessary for our legitimate interests (for running our business, provision of administration and IT services, network security, to prevent fraud and in the context of a business reorganisation or group restructuring exercise)<br/>(b) Necessary to comply with a legal obligation |
+| To use data analytics to improve our website, products/services, marketing,customer relationships and experiences | (a) Technical<br/>(b) Usage | Necessary for our legitimate interests (to define types of customers for our products and services, to keep our website updated and relevant, to develop our business and to inform our marketing strategy) |
+| To make suggestions and recommendations to you about goods or services that may be of interest to you | (a) Contact<br/>(b) Technical<br/>(c) Usage<br/>(d) Profile<br/>(e) Marketing and Communications | Necessary for our legitimate interests (to develop our products/services and grow our business) |
+
+- To carry out our obligations and enforce our rights.
+- In any other way we may describe when you provide the information.
+- For any other purpose with your consent.
+
+We may use information that is not personal information for any purpose. For example, we may aggregate usage data from many people in a way that does not identify any individuals to calculate the percentage of users accessing a feature on the website.
+
+## 8. Disclosure of Your Information <a id="DisclosureOfYourInfo"></a>
+
+We may share non-personal information without restriction. We may share your personal information with:
+
+- Any member of our corporate group, which means our subsidiaries, affiliates, our ultimate holding company and its subsidiaries, and affiliates.
+- To contractors, service providers, and other third parties we use to support our business.
+- If we offer a co-branded promotion, to our co-sponsor.
+- To fulfill the purpose for which you provide it.
+- For any other purposes that we disclose when you provide the information.
+- With your consent.
+
+We may also disclose your personal information:
+
+- To comply with any court order, law, or legal process, including responding to any government or regulatory request.
+- To enforce Terms of Use and other agreements including for billing and collections purposes.
+- To protect the rights, property, or safety of our business, our employees, our customers, or others. This includes exchanging information with other companies and organizations for the purposes of cybersecurity, fraud protection and credit risk reduction.
+- To investigate suspected violations of any law, rule or regulation, or the terms or policies for our website.
+
+## 9. Third Party Links <a id="ThirdPartyContent"></a>
+
+Some content or applications on our websites may be served by third parties, content providers and application providers including the following:
+
+  1. **Plugins.** Our website may make available the option for you to use &quot;plugins&quot; that are operated by social media companies. If you choose to use one of these plugins, then it may collect information about you and send it back to the social media company that owns it. This may happen even if you do not click on the plugin, if you are logged into the social media website that owns the plugin when you visit our website. Information collected by a plugin is subject to the privacy policy and terms of the social media company that makes it. If you do not want the social media company who owns a plugin to collect information about you when you visit our websites, sign out of the social media network before visiting. By interacting with a plugin when you are on our websites (for example, clicking the Facebook &quot;Like&quot; button), you are intentionally transferring information to that social media company. Further, if you are logged into a social media website when you visit our websites, then you are directing us to share your data with the social media company that owns the plugin.
+  2. **User Content.** Our websites may allow you to upload your own content to public areas of the website. Any information you submit becomes public information, and we do not control how others may use the content you submit. We are not responsible for uses that may violate our privacy policy, the law, or your intellectual property rights.
+  3. **Third-party links.** Our websites may contain links to other sites, which we do not control. Those websites have their own privacy policies and terms, and we encourage you to read those terms before interacting with third-party sites.
+
+## 10. Your Rights and Choices <a id="YourRightsAndChoices"></a>
+
+Your rights may vary depending on where you are located. We have created mechanisms to provide you with the following control over your information.
+
+- **Marketing**. If you do not want us to use your email address or other contact information to promote or recommend our own products and services, or third parties&#39; products or services, you can opt-out by checking the relevant box located on the form where we collect your contact information or, if presented with the option to opt-in, do not opt-in. You may also opt-out of further marketing communications by replying to any promotional email we have sent you or following the opt-out links on that message.
+- **Accessing, Updating and Deleting Your Information.** You can contact us as set forth in the _[Contact Us](#ContactUs)_ section below to request access to, correction of, or deletion of personal information that you have provided to us. We may not accommodate a request to change information if we believe the change would violate any law or legal requirement or negatively affect the information&#39;s accuracy. We cannot delete personal information, if any, that has been posted to the Ethereum blockchain through your use of a smart contract on our Network.
+- **Cookies and Automatic Data Collection Technologies**. You can set your browser to refuse all or some browser cookies, or to alert you when websites set or access cookies. However, if you disable or refuse cookies, please note that some parts of this website may become inaccessible or not function properly.
+- **California Residents**. If you are a California resident, you may have additional personal rights and choices with regard to your personal information. Please see _[Your California Privacy Rights](#YourCAPrivacyRights)_ for more information. California&#39;s &quot;Shine the Light&quot; law (Civil Code Section § 1798.83) permits users of our website that are California residents to request certain information regarding our disclosure of personal information to third parties for their direct marketing purposes. At this time, we do not engage in this type of disclosure.
+- **EU Residents.** If you are a resident of the European Union, you have the right to:
+  - request access to your personal data, commonly known as a &quot;data subject access request&quot;, which allows you to receive a copy of the personal data we hold about you and to check that we are lawfully processing it.
+  - Request a correction of the personal data that we hold about you. This enables you to have any incomplete or inaccurate data we hold about you corrected, though we may need to verify the accuracy of the new data you provide to us. You acknowledge we cannot correct data that has been posted to a public blockchain.
+  - Request erasure of your personal data. This enables you to ask us to delete or remove personal data where there is no good reason for us continuing to process it. You also have the right to ask us to delete or remove your personal data where you have successfully exercised your right to object to processing (see below), where we may have processed your information unlawfully or where we are required to erase your personal data to comply with local law. Note, however, that we may not always be able to comply with your request of erasure for specific legal reasons which will be notified to you, if applicable, at the time of your request. We cannot delete personal data that has been posted to a public blockchain.
+  - Object to processing of your personal data where we are relying on a legitimate interest (or those of a third party) and there is something about your particular situation which makes you want to object to processing on this ground as you feel it impacts on your fundamental rights and freedoms. In some cases, we may demonstrate that we have compelling legitimate grounds to process your information which override your rights and freedoms.
+  - Request restriction of processing of your personal data. This enables you to ask us to suspend the processing of your personal data in the following scenarios:
+    - If you want us to establish the data&#39;s accuracy.
+    - Where you need us to hold the data even if we no longer require it as you need it to establish, exercise or defend legal claims.
+    - You have objected to our use of your data but we need to verify whether we have overriding legitimate grounds to use it.
+  - Request the transfer of your personal data to you or to a third party. We will provide to you, or a third party you have chosen, your personal data in a structured, commonly used, machine-readable format. Note that this right only applies to automated information which you initially provided consent for us to use or where we used the information to perform a contract with you.
+  - Withdraw consent at any time where we are relying on consent to process your personal data. However, this will not affect the lawfulness of any processing carried out before you withdraw your consent. If you withdraw your consent, we may not be able to provide certain products or services to you. We will advise you if this is the case at the time you withdraw your consent. You acknowledge you cannot withdraw consent from participating in a smart contract that has already been executed.
+
+## 11. Data Security <a id="DataSecurity"></a>
+
+The security of your personal information is very important to us. We use physical, electronic, and administrative safeguards designed to protect your personal information from loss, misuse and unauthorized access, use, alteration or disclosure. We will only retain your personal information for as long as reasonably necessary to fulfil the purpose of collecting it.
+
+The safety and security of your information also depends on you. You are responsible for keeping your wallet address and your personal information confidential. We ask you not to share your wallet&#39;s private key with anyone. We urge you to take care when providing information to social media accounts or message boards, which any website visitor can view.
+
+## 12. Your California Privacy Rights <a id="YourCaliforniaPrivacyRights"></a>
+
+If you are a California resident, California law may provide you with additional rights regarding our use of your personal information. To learn more about your California privacy rights, you can view our [Privacy Notice for California Residents](/california-privacy-notice).
+
+## 13. Changes to Our Privacy Policy <a id="ChangesToOurPrivacyPolicy"></a>
+
+We will post any changes we may make to our privacy policy on this page. If the changes materially alter how we use or treat your information we will notify you through a notice on the website home page. The date the privacy policy was last revised is identified at the top of the page.
+
+## 14. Contact Us <a id="ContactUs"></a>
+
+If you have any comments or questions about our privacy policy, please contact our data privacy manager at [legal@keep.network](mailto:legal@keep.network).

--- a/src/pages/privacy-policy/index.fr.md
+++ b/src/pages/privacy-policy/index.fr.md
@@ -1,0 +1,156 @@
+---
+template: 'legal-page'
+path: /privacy-policy
+title: Privacy Policy
+---
+Effective and last modified: January 1, 2020
+
+At Keep SECZ, we respect your privacy and are committed to protecting it.
+
+This notice covers all personal information collected in the use of this website, as well as any other websites, applications, or connected products on which it is posted. If in any case our privacy practices differ from those explained in this policy, we will let you know you at the time we ask for or collect your information.
+
+Some pages on our websites may contain links to third-party websites. We do not endorse and have no control over the privacy practices or content of such websites. We recommend you carefully read the privacy policy of each site you visit – including ours.
+
+## 1. We cover a lot of ground in this privacy policy. Use the links below to navigate to later sections of the privacy policy of interest to you.
+- _[The Controller](#Controller)_
+- _[What information we collect about you](#WhatInfoWeCollect)_
+- _[Children&#39;s Online Privacy](#ChildrensOnlinePrivacy)_
+- _[How we collect personal information about you](#HowWeCollectInfo)_
+- _[Cookies and automatic data collection technologies](#CookiesAndAutoDataCollection)_
+- _[How we use your personal information](#HowWeUseYourInfo)_
+- _[Disclosure of Your Information](#DisclosureOfYourInfo)_
+- _[Third Party Content](#ThirdPartyContent)_
+- _[Your Rights and Choices](#YourRightsAndChoices)_
+- _[Data Security](#DataSecurity)_
+- _[Your California Privacy Rights](#YourCaliforniaPrivacyRights)_
+- _[Changes to Our Privacy Policy](#ChangesToOurPrivacyPolicy)_
+- _[Contact Us](#ContactUs)_
+
+## 2. Controller <a id="Controller"></a>
+
+Keep SECZ (collectively referred to as &quot;COMPANY&quot;, &quot;we&quot;, &quot;us&quot; or &quot;our&quot;) in this privacy policy is the controller and responsible for your personal data. We have appointed a data privacy manager who is responsible for overseeing questions in relation to this privacy policy. If you have any questions about this privacy policy, including any requests to exercise your legal rights, please contact the data privacy manager using the details set forth below.
+
+## 3. What information we collect <a id="WhatInfoWeCollect"></a>
+
+Personal information, or personal data, means any information about an individual from which that person can be identified. It does not include data where the identity has been removed (anonymous data), which we can use for any purpose. Some jurisdictions may consider your Ethereum wallet address to be personal data. We may collect, use, store and transfer different kinds of personal information about you which we have grouped together as follows:
+
+- **Identity or Contact Data** includes your email address or similar identifiers or contact information.
+- **Financial information** may include your Ethereum wallet address.
+- **Usage Data** includes information about how you use our websites and our products and services.
+- **Marketing and Communications Data** includes your preferences in receiving marketing from us and your communication preferences.
+
+We may also collect, use and share Aggregated Data such as statistical or demographic data for any purpose. Aggregated Data could be derived from your personal data but is not considered personal data in law as this data will not directly or indirectly reveal your identity. For example, we may aggregate your Usage Data to calculate the percentage of users accessing a specific Network feature. However, if we combine or connect Aggregated Data with your personal data so that it can directly or indirectly identify you, we treat the combined data as personal data which will be used in accordance with this privacy policy.
+
+We do not collect any Special Categories of Personal Data about you (this includes details about your race or ethnicity, religious or philosophical beliefs, sex life, sexual orientation, political opinions, trade union membership, information about your health, and genetic and biometric data). Nor do we collect any information about criminal convictions and offences.
+
+We do not retain information about your transaction history, but you acknowledge that the smart contract transactions facilitated by the Network are recorded in perpetuity on the Ethereum blockchain and cannot be reversed or erased. By using the Network and its smart contracts, you acknowledge that the posting of information concerning your Ethereum wallet address is a function of the smart contract functionality to which you agree.
+
+## 4. Children&#39;s data <a id="ChildrensOnlinePrivacy"></a>
+
+We do not direct our websites to minors, and we do not knowingly collect personal information from children under 18. If you are under 18, do not use or provide any information on this website. If we learn we have collected or received personal information from a child under 18 without verification of parental consent, we will delete that information. If you believe we might have any information from or about a child under 18 please contact us using our Contact Us page.
+
+## 5. How we collect your information <a id="HowWeCollectInfo"></a>
+
+We use different methods to collect information from and about you including through:
+
+- **Direct interactions.** You may give us information about you by interacting with our smart contracts or by communicating with us e-mail, or otherwise. This includes information you provide when you use our Network, subscribe to one of our newsletters or other communications, join a user group, complete a survey, or when you contact us about one of our products, or services.
+- **Third parties or publicly available sources.** We may receive information about you from third parties including, for example, our affiliated companies, business partners, sub-contractors, analytics providers, and service providers.
+- **Technical Data from the following parties:**
+  - Analytics providers such as Crowdcast.
+
+## 6. Cookies and automatic data collection technologies <a id="CookiesAndAutoDataCollection"></a>
+
+Our websites may use automatic data collection technologies to distinguish you from other website users. This helps us deliver a better and more personalized service when you browse our website. It also allows us to improve our websites by enabling us to:
+
+- Estimate our audience size and usage patterns.
+- Store your preferences so we may customize our websites according to your individual interests.
+- Recognize you when you return to our website.
+
+The technologies we use for this automatic data collection may include:
+
+- **Cookies (or browser cookies).**A cookie is a small file placed on the hard drive of your computer. For information about managing browser settings to refuse cookies, see _[Your Rights and Choices](#YourCaliforniaPrivacyRights)_.
+
+We do not respond to or honor &quot;do not track&quot; (a/k/a DNT) signals or similar mechanisms transmitted by web browsers.
+
+## 7. How we use your personal information <a id="HowWeUseYourInfo"></a>
+
+If you provide personal information through the features on our website, we will only use your personal information as the law allows. Examples the activities for which we may collect information, the type of data we collect, and our lawful basis for collecting that data are listed below.
+
+| **Purpose/Activity** | **Type of data** | **Lawful basis for processing including basis of legitimate interest** |
+| --- | --- | --- |
+| To register you for our newsletter | (a) Contact | Performance of a contract with you |
+| To process your smart contract transactions | (a) Wallet address<br/>(b) Contact | (a) Performance of a contract with you<br/>(b) Necessary for our legitimate interests (to collect our fees) |
+| To manage our relationship with you which will include:<br/>(a) Notifying you about changes to our terms or privacy policy<br/>(b) Asking you to leave a review or take a survey | (a) Contact<br/>(b) Profile<br/>(c) Marketing and Communications | (a) Performance of a contract with you<br/>(b) Necessary to comply with a legal obligation<br/>(c) Necessary for our legitimate interests (to keep our records updated and to study how customers use our products/services) |
+| To administer and protect our business and this website (including troubleshooting, data analysis, testing, system maintenance, support, reporting and hosting of data) | (a) Contact<br/>(b) Technical | (a) Necessary for our legitimate interests (for running our business, provision of administration and IT services, network security, to prevent fraud and in the context of a business reorganisation or group restructuring exercise)<br/>(b) Necessary to comply with a legal obligation |
+| To use data analytics to improve our website, products/services, marketing,customer relationships and experiences | (a) Technical<br/>(b) Usage | Necessary for our legitimate interests (to define types of customers for our products and services, to keep our website updated and relevant, to develop our business and to inform our marketing strategy) |
+| To make suggestions and recommendations to you about goods or services that may be of interest to you | (a) Contact<br/>(b) Technical<br/>(c) Usage<br/>(d) Profile<br/>(e) Marketing and Communications | Necessary for our legitimate interests (to develop our products/services and grow our business) |
+
+- To carry out our obligations and enforce our rights.
+- In any other way we may describe when you provide the information.
+- For any other purpose with your consent.
+
+We may use information that is not personal information for any purpose. For example, we may aggregate usage data from many people in a way that does not identify any individuals to calculate the percentage of users accessing a feature on the website.
+
+## 8. Disclosure of Your Information <a id="DisclosureOfYourInfo"></a>
+
+We may share non-personal information without restriction. We may share your personal information with:
+
+- Any member of our corporate group, which means our subsidiaries, affiliates, our ultimate holding company and its subsidiaries, and affiliates.
+- To contractors, service providers, and other third parties we use to support our business.
+- If we offer a co-branded promotion, to our co-sponsor.
+- To fulfill the purpose for which you provide it.
+- For any other purposes that we disclose when you provide the information.
+- With your consent.
+
+We may also disclose your personal information:
+
+- To comply with any court order, law, or legal process, including responding to any government or regulatory request.
+- To enforce Terms of Use and other agreements including for billing and collections purposes.
+- To protect the rights, property, or safety of our business, our employees, our customers, or others. This includes exchanging information with other companies and organizations for the purposes of cybersecurity, fraud protection and credit risk reduction.
+- To investigate suspected violations of any law, rule or regulation, or the terms or policies for our website.
+
+## 9. Third Party Links <a id="ThirdPartyContent"></a>
+
+Some content or applications on our websites may be served by third parties, content providers and application providers including the following:
+
+  1. **Plugins.** Our website may make available the option for you to use &quot;plugins&quot; that are operated by social media companies. If you choose to use one of these plugins, then it may collect information about you and send it back to the social media company that owns it. This may happen even if you do not click on the plugin, if you are logged into the social media website that owns the plugin when you visit our website. Information collected by a plugin is subject to the privacy policy and terms of the social media company that makes it. If you do not want the social media company who owns a plugin to collect information about you when you visit our websites, sign out of the social media network before visiting. By interacting with a plugin when you are on our websites (for example, clicking the Facebook &quot;Like&quot; button), you are intentionally transferring information to that social media company. Further, if you are logged into a social media website when you visit our websites, then you are directing us to share your data with the social media company that owns the plugin.
+  2. **User Content.** Our websites may allow you to upload your own content to public areas of the website. Any information you submit becomes public information, and we do not control how others may use the content you submit. We are not responsible for uses that may violate our privacy policy, the law, or your intellectual property rights.
+  3. **Third-party links.** Our websites may contain links to other sites, which we do not control. Those websites have their own privacy policies and terms, and we encourage you to read those terms before interacting with third-party sites.
+
+## 10. Your Rights and Choices <a id="YourRightsAndChoices"></a>
+
+Your rights may vary depending on where you are located. We have created mechanisms to provide you with the following control over your information.
+
+- **Marketing**. If you do not want us to use your email address or other contact information to promote or recommend our own products and services, or third parties&#39; products or services, you can opt-out by checking the relevant box located on the form where we collect your contact information or, if presented with the option to opt-in, do not opt-in. You may also opt-out of further marketing communications by replying to any promotional email we have sent you or following the opt-out links on that message.
+- **Accessing, Updating and Deleting Your Information.** You can contact us as set forth in the _[Contact Us](#ContactUs)_ section below to request access to, correction of, or deletion of personal information that you have provided to us. We may not accommodate a request to change information if we believe the change would violate any law or legal requirement or negatively affect the information&#39;s accuracy. We cannot delete personal information, if any, that has been posted to the Ethereum blockchain through your use of a smart contract on our Network.
+- **Cookies and Automatic Data Collection Technologies**. You can set your browser to refuse all or some browser cookies, or to alert you when websites set or access cookies. However, if you disable or refuse cookies, please note that some parts of this website may become inaccessible or not function properly.
+- **California Residents**. If you are a California resident, you may have additional personal rights and choices with regard to your personal information. Please see _[Your California Privacy Rights](#YourCAPrivacyRights)_ for more information. California&#39;s &quot;Shine the Light&quot; law (Civil Code Section § 1798.83) permits users of our website that are California residents to request certain information regarding our disclosure of personal information to third parties for their direct marketing purposes. At this time, we do not engage in this type of disclosure.
+- **EU Residents.** If you are a resident of the European Union, you have the right to:
+  - request access to your personal data, commonly known as a &quot;data subject access request&quot;, which allows you to receive a copy of the personal data we hold about you and to check that we are lawfully processing it.
+  - Request a correction of the personal data that we hold about you. This enables you to have any incomplete or inaccurate data we hold about you corrected, though we may need to verify the accuracy of the new data you provide to us. You acknowledge we cannot correct data that has been posted to a public blockchain.
+  - Request erasure of your personal data. This enables you to ask us to delete or remove personal data where there is no good reason for us continuing to process it. You also have the right to ask us to delete or remove your personal data where you have successfully exercised your right to object to processing (see below), where we may have processed your information unlawfully or where we are required to erase your personal data to comply with local law. Note, however, that we may not always be able to comply with your request of erasure for specific legal reasons which will be notified to you, if applicable, at the time of your request. We cannot delete personal data that has been posted to a public blockchain.
+  - Object to processing of your personal data where we are relying on a legitimate interest (or those of a third party) and there is something about your particular situation which makes you want to object to processing on this ground as you feel it impacts on your fundamental rights and freedoms. In some cases, we may demonstrate that we have compelling legitimate grounds to process your information which override your rights and freedoms.
+  - Request restriction of processing of your personal data. This enables you to ask us to suspend the processing of your personal data in the following scenarios:
+    - If you want us to establish the data&#39;s accuracy.
+    - Where you need us to hold the data even if we no longer require it as you need it to establish, exercise or defend legal claims.
+    - You have objected to our use of your data but we need to verify whether we have overriding legitimate grounds to use it.
+  - Request the transfer of your personal data to you or to a third party. We will provide to you, or a third party you have chosen, your personal data in a structured, commonly used, machine-readable format. Note that this right only applies to automated information which you initially provided consent for us to use or where we used the information to perform a contract with you.
+  - Withdraw consent at any time where we are relying on consent to process your personal data. However, this will not affect the lawfulness of any processing carried out before you withdraw your consent. If you withdraw your consent, we may not be able to provide certain products or services to you. We will advise you if this is the case at the time you withdraw your consent. You acknowledge you cannot withdraw consent from participating in a smart contract that has already been executed.
+
+## 11. Data Security <a id="DataSecurity"></a>
+
+The security of your personal information is very important to us. We use physical, electronic, and administrative safeguards designed to protect your personal information from loss, misuse and unauthorized access, use, alteration or disclosure. We will only retain your personal information for as long as reasonably necessary to fulfil the purpose of collecting it.
+
+The safety and security of your information also depends on you. You are responsible for keeping your wallet address and your personal information confidential. We ask you not to share your wallet&#39;s private key with anyone. We urge you to take care when providing information to social media accounts or message boards, which any website visitor can view.
+
+## 12. Your California Privacy Rights <a id="YourCaliforniaPrivacyRights"></a>
+
+If you are a California resident, California law may provide you with additional rights regarding our use of your personal information. To learn more about your California privacy rights, you can view our [Privacy Notice for California Residents](/california-privacy-notice).
+
+## 13. Changes to Our Privacy Policy <a id="ChangesToOurPrivacyPolicy"></a>
+
+We will post any changes we may make to our privacy policy on this page. If the changes materially alter how we use or treat your information we will notify you through a notice on the website home page. The date the privacy policy was last revised is identified at the top of the page.
+
+## 14. Contact Us <a id="ContactUs"></a>
+
+If you have any comments or questions about our privacy policy, please contact our data privacy manager at [legal@keep.network](mailto:legal@keep.network).

--- a/src/pages/privacy-policy/index.pl.md
+++ b/src/pages/privacy-policy/index.pl.md
@@ -1,0 +1,156 @@
+---
+template: 'legal-page'
+path: /privacy-policy
+title: Privacy Policy
+---
+Effective and last modified: January 1, 2020
+
+At Keep SECZ, we respect your privacy and are committed to protecting it.
+
+This notice covers all personal information collected in the use of this website, as well as any other websites, applications, or connected products on which it is posted. If in any case our privacy practices differ from those explained in this policy, we will let you know you at the time we ask for or collect your information.
+
+Some pages on our websites may contain links to third-party websites. We do not endorse and have no control over the privacy practices or content of such websites. We recommend you carefully read the privacy policy of each site you visit – including ours.
+
+## 1. We cover a lot of ground in this privacy policy. Use the links below to navigate to later sections of the privacy policy of interest to you.
+- _[The Controller](#Controller)_
+- _[What information we collect about you](#WhatInfoWeCollect)_
+- _[Children&#39;s Online Privacy](#ChildrensOnlinePrivacy)_
+- _[How we collect personal information about you](#HowWeCollectInfo)_
+- _[Cookies and automatic data collection technologies](#CookiesAndAutoDataCollection)_
+- _[How we use your personal information](#HowWeUseYourInfo)_
+- _[Disclosure of Your Information](#DisclosureOfYourInfo)_
+- _[Third Party Content](#ThirdPartyContent)_
+- _[Your Rights and Choices](#YourRightsAndChoices)_
+- _[Data Security](#DataSecurity)_
+- _[Your California Privacy Rights](#YourCaliforniaPrivacyRights)_
+- _[Changes to Our Privacy Policy](#ChangesToOurPrivacyPolicy)_
+- _[Contact Us](#ContactUs)_
+
+## 2. Controller <a id="Controller"></a>
+
+Keep SECZ (collectively referred to as &quot;COMPANY&quot;, &quot;we&quot;, &quot;us&quot; or &quot;our&quot;) in this privacy policy is the controller and responsible for your personal data. We have appointed a data privacy manager who is responsible for overseeing questions in relation to this privacy policy. If you have any questions about this privacy policy, including any requests to exercise your legal rights, please contact the data privacy manager using the details set forth below.
+
+## 3. What information we collect <a id="WhatInfoWeCollect"></a>
+
+Personal information, or personal data, means any information about an individual from which that person can be identified. It does not include data where the identity has been removed (anonymous data), which we can use for any purpose. Some jurisdictions may consider your Ethereum wallet address to be personal data. We may collect, use, store and transfer different kinds of personal information about you which we have grouped together as follows:
+
+- **Identity or Contact Data** includes your email address or similar identifiers or contact information.
+- **Financial information** may include your Ethereum wallet address.
+- **Usage Data** includes information about how you use our websites and our products and services.
+- **Marketing and Communications Data** includes your preferences in receiving marketing from us and your communication preferences.
+
+We may also collect, use and share Aggregated Data such as statistical or demographic data for any purpose. Aggregated Data could be derived from your personal data but is not considered personal data in law as this data will not directly or indirectly reveal your identity. For example, we may aggregate your Usage Data to calculate the percentage of users accessing a specific Network feature. However, if we combine or connect Aggregated Data with your personal data so that it can directly or indirectly identify you, we treat the combined data as personal data which will be used in accordance with this privacy policy.
+
+We do not collect any Special Categories of Personal Data about you (this includes details about your race or ethnicity, religious or philosophical beliefs, sex life, sexual orientation, political opinions, trade union membership, information about your health, and genetic and biometric data). Nor do we collect any information about criminal convictions and offences.
+
+We do not retain information about your transaction history, but you acknowledge that the smart contract transactions facilitated by the Network are recorded in perpetuity on the Ethereum blockchain and cannot be reversed or erased. By using the Network and its smart contracts, you acknowledge that the posting of information concerning your Ethereum wallet address is a function of the smart contract functionality to which you agree.
+
+## 4. Children&#39;s data <a id="ChildrensOnlinePrivacy"></a>
+
+We do not direct our websites to minors, and we do not knowingly collect personal information from children under 18. If you are under 18, do not use or provide any information on this website. If we learn we have collected or received personal information from a child under 18 without verification of parental consent, we will delete that information. If you believe we might have any information from or about a child under 18 please contact us using our Contact Us page.
+
+## 5. How we collect your information <a id="HowWeCollectInfo"></a>
+
+We use different methods to collect information from and about you including through:
+
+- **Direct interactions.** You may give us information about you by interacting with our smart contracts or by communicating with us e-mail, or otherwise. This includes information you provide when you use our Network, subscribe to one of our newsletters or other communications, join a user group, complete a survey, or when you contact us about one of our products, or services.
+- **Third parties or publicly available sources.** We may receive information about you from third parties including, for example, our affiliated companies, business partners, sub-contractors, analytics providers, and service providers.
+- **Technical Data from the following parties:**
+  - Analytics providers such as Crowdcast.
+
+## 6. Cookies and automatic data collection technologies <a id="CookiesAndAutoDataCollection"></a>
+
+Our websites may use automatic data collection technologies to distinguish you from other website users. This helps us deliver a better and more personalized service when you browse our website. It also allows us to improve our websites by enabling us to:
+
+- Estimate our audience size and usage patterns.
+- Store your preferences so we may customize our websites according to your individual interests.
+- Recognize you when you return to our website.
+
+The technologies we use for this automatic data collection may include:
+
+- **Cookies (or browser cookies).**A cookie is a small file placed on the hard drive of your computer. For information about managing browser settings to refuse cookies, see _[Your Rights and Choices](#YourCaliforniaPrivacyRights)_.
+
+We do not respond to or honor &quot;do not track&quot; (a/k/a DNT) signals or similar mechanisms transmitted by web browsers.
+
+## 7. How we use your personal information <a id="HowWeUseYourInfo"></a>
+
+If you provide personal information through the features on our website, we will only use your personal information as the law allows. Examples the activities for which we may collect information, the type of data we collect, and our lawful basis for collecting that data are listed below.
+
+| **Purpose/Activity** | **Type of data** | **Lawful basis for processing including basis of legitimate interest** |
+| --- | --- | --- |
+| To register you for our newsletter | (a) Contact | Performance of a contract with you |
+| To process your smart contract transactions | (a) Wallet address<br/>(b) Contact | (a) Performance of a contract with you<br/>(b) Necessary for our legitimate interests (to collect our fees) |
+| To manage our relationship with you which will include:<br/>(a) Notifying you about changes to our terms or privacy policy<br/>(b) Asking you to leave a review or take a survey | (a) Contact<br/>(b) Profile<br/>(c) Marketing and Communications | (a) Performance of a contract with you<br/>(b) Necessary to comply with a legal obligation<br/>(c) Necessary for our legitimate interests (to keep our records updated and to study how customers use our products/services) |
+| To administer and protect our business and this website (including troubleshooting, data analysis, testing, system maintenance, support, reporting and hosting of data) | (a) Contact<br/>(b) Technical | (a) Necessary for our legitimate interests (for running our business, provision of administration and IT services, network security, to prevent fraud and in the context of a business reorganisation or group restructuring exercise)<br/>(b) Necessary to comply with a legal obligation |
+| To use data analytics to improve our website, products/services, marketing,customer relationships and experiences | (a) Technical<br/>(b) Usage | Necessary for our legitimate interests (to define types of customers for our products and services, to keep our website updated and relevant, to develop our business and to inform our marketing strategy) |
+| To make suggestions and recommendations to you about goods or services that may be of interest to you | (a) Contact<br/>(b) Technical<br/>(c) Usage<br/>(d) Profile<br/>(e) Marketing and Communications | Necessary for our legitimate interests (to develop our products/services and grow our business) |
+
+- To carry out our obligations and enforce our rights.
+- In any other way we may describe when you provide the information.
+- For any other purpose with your consent.
+
+We may use information that is not personal information for any purpose. For example, we may aggregate usage data from many people in a way that does not identify any individuals to calculate the percentage of users accessing a feature on the website.
+
+## 8. Disclosure of Your Information <a id="DisclosureOfYourInfo"></a>
+
+We may share non-personal information without restriction. We may share your personal information with:
+
+- Any member of our corporate group, which means our subsidiaries, affiliates, our ultimate holding company and its subsidiaries, and affiliates.
+- To contractors, service providers, and other third parties we use to support our business.
+- If we offer a co-branded promotion, to our co-sponsor.
+- To fulfill the purpose for which you provide it.
+- For any other purposes that we disclose when you provide the information.
+- With your consent.
+
+We may also disclose your personal information:
+
+- To comply with any court order, law, or legal process, including responding to any government or regulatory request.
+- To enforce Terms of Use and other agreements including for billing and collections purposes.
+- To protect the rights, property, or safety of our business, our employees, our customers, or others. This includes exchanging information with other companies and organizations for the purposes of cybersecurity, fraud protection and credit risk reduction.
+- To investigate suspected violations of any law, rule or regulation, or the terms or policies for our website.
+
+## 9. Third Party Links <a id="ThirdPartyContent"></a>
+
+Some content or applications on our websites may be served by third parties, content providers and application providers including the following:
+
+  1. **Plugins.** Our website may make available the option for you to use &quot;plugins&quot; that are operated by social media companies. If you choose to use one of these plugins, then it may collect information about you and send it back to the social media company that owns it. This may happen even if you do not click on the plugin, if you are logged into the social media website that owns the plugin when you visit our website. Information collected by a plugin is subject to the privacy policy and terms of the social media company that makes it. If you do not want the social media company who owns a plugin to collect information about you when you visit our websites, sign out of the social media network before visiting. By interacting with a plugin when you are on our websites (for example, clicking the Facebook &quot;Like&quot; button), you are intentionally transferring information to that social media company. Further, if you are logged into a social media website when you visit our websites, then you are directing us to share your data with the social media company that owns the plugin.
+  2. **User Content.** Our websites may allow you to upload your own content to public areas of the website. Any information you submit becomes public information, and we do not control how others may use the content you submit. We are not responsible for uses that may violate our privacy policy, the law, or your intellectual property rights.
+  3. **Third-party links.** Our websites may contain links to other sites, which we do not control. Those websites have their own privacy policies and terms, and we encourage you to read those terms before interacting with third-party sites.
+
+## 10. Your Rights and Choices <a id="YourRightsAndChoices"></a>
+
+Your rights may vary depending on where you are located. We have created mechanisms to provide you with the following control over your information.
+
+- **Marketing**. If you do not want us to use your email address or other contact information to promote or recommend our own products and services, or third parties&#39; products or services, you can opt-out by checking the relevant box located on the form where we collect your contact information or, if presented with the option to opt-in, do not opt-in. You may also opt-out of further marketing communications by replying to any promotional email we have sent you or following the opt-out links on that message.
+- **Accessing, Updating and Deleting Your Information.** You can contact us as set forth in the _[Contact Us](#ContactUs)_ section below to request access to, correction of, or deletion of personal information that you have provided to us. We may not accommodate a request to change information if we believe the change would violate any law or legal requirement or negatively affect the information&#39;s accuracy. We cannot delete personal information, if any, that has been posted to the Ethereum blockchain through your use of a smart contract on our Network.
+- **Cookies and Automatic Data Collection Technologies**. You can set your browser to refuse all or some browser cookies, or to alert you when websites set or access cookies. However, if you disable or refuse cookies, please note that some parts of this website may become inaccessible or not function properly.
+- **California Residents**. If you are a California resident, you may have additional personal rights and choices with regard to your personal information. Please see _[Your California Privacy Rights](#YourCAPrivacyRights)_ for more information. California&#39;s &quot;Shine the Light&quot; law (Civil Code Section § 1798.83) permits users of our website that are California residents to request certain information regarding our disclosure of personal information to third parties for their direct marketing purposes. At this time, we do not engage in this type of disclosure.
+- **EU Residents.** If you are a resident of the European Union, you have the right to:
+  - request access to your personal data, commonly known as a &quot;data subject access request&quot;, which allows you to receive a copy of the personal data we hold about you and to check that we are lawfully processing it.
+  - Request a correction of the personal data that we hold about you. This enables you to have any incomplete or inaccurate data we hold about you corrected, though we may need to verify the accuracy of the new data you provide to us. You acknowledge we cannot correct data that has been posted to a public blockchain.
+  - Request erasure of your personal data. This enables you to ask us to delete or remove personal data where there is no good reason for us continuing to process it. You also have the right to ask us to delete or remove your personal data where you have successfully exercised your right to object to processing (see below), where we may have processed your information unlawfully or where we are required to erase your personal data to comply with local law. Note, however, that we may not always be able to comply with your request of erasure for specific legal reasons which will be notified to you, if applicable, at the time of your request. We cannot delete personal data that has been posted to a public blockchain.
+  - Object to processing of your personal data where we are relying on a legitimate interest (or those of a third party) and there is something about your particular situation which makes you want to object to processing on this ground as you feel it impacts on your fundamental rights and freedoms. In some cases, we may demonstrate that we have compelling legitimate grounds to process your information which override your rights and freedoms.
+  - Request restriction of processing of your personal data. This enables you to ask us to suspend the processing of your personal data in the following scenarios:
+    - If you want us to establish the data&#39;s accuracy.
+    - Where you need us to hold the data even if we no longer require it as you need it to establish, exercise or defend legal claims.
+    - You have objected to our use of your data but we need to verify whether we have overriding legitimate grounds to use it.
+  - Request the transfer of your personal data to you or to a third party. We will provide to you, or a third party you have chosen, your personal data in a structured, commonly used, machine-readable format. Note that this right only applies to automated information which you initially provided consent for us to use or where we used the information to perform a contract with you.
+  - Withdraw consent at any time where we are relying on consent to process your personal data. However, this will not affect the lawfulness of any processing carried out before you withdraw your consent. If you withdraw your consent, we may not be able to provide certain products or services to you. We will advise you if this is the case at the time you withdraw your consent. You acknowledge you cannot withdraw consent from participating in a smart contract that has already been executed.
+
+## 11. Data Security <a id="DataSecurity"></a>
+
+The security of your personal information is very important to us. We use physical, electronic, and administrative safeguards designed to protect your personal information from loss, misuse and unauthorized access, use, alteration or disclosure. We will only retain your personal information for as long as reasonably necessary to fulfil the purpose of collecting it.
+
+The safety and security of your information also depends on you. You are responsible for keeping your wallet address and your personal information confidential. We ask you not to share your wallet&#39;s private key with anyone. We urge you to take care when providing information to social media accounts or message boards, which any website visitor can view.
+
+## 12. Your California Privacy Rights <a id="YourCaliforniaPrivacyRights"></a>
+
+If you are a California resident, California law may provide you with additional rights regarding our use of your personal information. To learn more about your California privacy rights, you can view our [Privacy Notice for California Residents](/california-privacy-notice).
+
+## 13. Changes to Our Privacy Policy <a id="ChangesToOurPrivacyPolicy"></a>
+
+We will post any changes we may make to our privacy policy on this page. If the changes materially alter how we use or treat your information we will notify you through a notice on the website home page. The date the privacy policy was last revised is identified at the top of the page.
+
+## 14. Contact Us <a id="ContactUs"></a>
+
+If you have any comments or questions about our privacy policy, please contact our data privacy manager at [legal@keep.network](mailto:legal@keep.network).

--- a/src/pages/privacy-policy/index.ru.md
+++ b/src/pages/privacy-policy/index.ru.md
@@ -1,0 +1,156 @@
+---
+template: 'legal-page'
+path: /privacy-policy
+title: Privacy Policy
+---
+Effective and last modified: January 1, 2020
+
+At Keep SECZ, we respect your privacy and are committed to protecting it.
+
+This notice covers all personal information collected in the use of this website, as well as any other websites, applications, or connected products on which it is posted. If in any case our privacy practices differ from those explained in this policy, we will let you know you at the time we ask for or collect your information.
+
+Some pages on our websites may contain links to third-party websites. We do not endorse and have no control over the privacy practices or content of such websites. We recommend you carefully read the privacy policy of each site you visit – including ours.
+
+## 1. We cover a lot of ground in this privacy policy. Use the links below to navigate to later sections of the privacy policy of interest to you.
+- _[The Controller](#Controller)_
+- _[What information we collect about you](#WhatInfoWeCollect)_
+- _[Children&#39;s Online Privacy](#ChildrensOnlinePrivacy)_
+- _[How we collect personal information about you](#HowWeCollectInfo)_
+- _[Cookies and automatic data collection technologies](#CookiesAndAutoDataCollection)_
+- _[How we use your personal information](#HowWeUseYourInfo)_
+- _[Disclosure of Your Information](#DisclosureOfYourInfo)_
+- _[Third Party Content](#ThirdPartyContent)_
+- _[Your Rights and Choices](#YourRightsAndChoices)_
+- _[Data Security](#DataSecurity)_
+- _[Your California Privacy Rights](#YourCaliforniaPrivacyRights)_
+- _[Changes to Our Privacy Policy](#ChangesToOurPrivacyPolicy)_
+- _[Contact Us](#ContactUs)_
+
+## 2. Controller <a id="Controller"></a>
+
+Keep SECZ (collectively referred to as &quot;COMPANY&quot;, &quot;we&quot;, &quot;us&quot; or &quot;our&quot;) in this privacy policy is the controller and responsible for your personal data. We have appointed a data privacy manager who is responsible for overseeing questions in relation to this privacy policy. If you have any questions about this privacy policy, including any requests to exercise your legal rights, please contact the data privacy manager using the details set forth below.
+
+## 3. What information we collect <a id="WhatInfoWeCollect"></a>
+
+Personal information, or personal data, means any information about an individual from which that person can be identified. It does not include data where the identity has been removed (anonymous data), which we can use for any purpose. Some jurisdictions may consider your Ethereum wallet address to be personal data. We may collect, use, store and transfer different kinds of personal information about you which we have grouped together as follows:
+
+- **Identity or Contact Data** includes your email address or similar identifiers or contact information.
+- **Financial information** may include your Ethereum wallet address.
+- **Usage Data** includes information about how you use our websites and our products and services.
+- **Marketing and Communications Data** includes your preferences in receiving marketing from us and your communication preferences.
+
+We may also collect, use and share Aggregated Data such as statistical or demographic data for any purpose. Aggregated Data could be derived from your personal data but is not considered personal data in law as this data will not directly or indirectly reveal your identity. For example, we may aggregate your Usage Data to calculate the percentage of users accessing a specific Network feature. However, if we combine or connect Aggregated Data with your personal data so that it can directly or indirectly identify you, we treat the combined data as personal data which will be used in accordance with this privacy policy.
+
+We do not collect any Special Categories of Personal Data about you (this includes details about your race or ethnicity, religious or philosophical beliefs, sex life, sexual orientation, political opinions, trade union membership, information about your health, and genetic and biometric data). Nor do we collect any information about criminal convictions and offences.
+
+We do not retain information about your transaction history, but you acknowledge that the smart contract transactions facilitated by the Network are recorded in perpetuity on the Ethereum blockchain and cannot be reversed or erased. By using the Network and its smart contracts, you acknowledge that the posting of information concerning your Ethereum wallet address is a function of the smart contract functionality to which you agree.
+
+## 4. Children&#39;s data <a id="ChildrensOnlinePrivacy"></a>
+
+We do not direct our websites to minors, and we do not knowingly collect personal information from children under 18. If you are under 18, do not use or provide any information on this website. If we learn we have collected or received personal information from a child under 18 without verification of parental consent, we will delete that information. If you believe we might have any information from or about a child under 18 please contact us using our Contact Us page.
+
+## 5. How we collect your information <a id="HowWeCollectInfo"></a>
+
+We use different methods to collect information from and about you including through:
+
+- **Direct interactions.** You may give us information about you by interacting with our smart contracts or by communicating with us e-mail, or otherwise. This includes information you provide when you use our Network, subscribe to one of our newsletters or other communications, join a user group, complete a survey, or when you contact us about one of our products, or services.
+- **Third parties or publicly available sources.** We may receive information about you from third parties including, for example, our affiliated companies, business partners, sub-contractors, analytics providers, and service providers.
+- **Technical Data from the following parties:**
+  - Analytics providers such as Crowdcast.
+
+## 6. Cookies and automatic data collection technologies <a id="CookiesAndAutoDataCollection"></a>
+
+Our websites may use automatic data collection technologies to distinguish you from other website users. This helps us deliver a better and more personalized service when you browse our website. It also allows us to improve our websites by enabling us to:
+
+- Estimate our audience size and usage patterns.
+- Store your preferences so we may customize our websites according to your individual interests.
+- Recognize you when you return to our website.
+
+The technologies we use for this automatic data collection may include:
+
+- **Cookies (or browser cookies).**A cookie is a small file placed on the hard drive of your computer. For information about managing browser settings to refuse cookies, see _[Your Rights and Choices](#YourCaliforniaPrivacyRights)_.
+
+We do not respond to or honor &quot;do not track&quot; (a/k/a DNT) signals or similar mechanisms transmitted by web browsers.
+
+## 7. How we use your personal information <a id="HowWeUseYourInfo"></a>
+
+If you provide personal information through the features on our website, we will only use your personal information as the law allows. Examples the activities for which we may collect information, the type of data we collect, and our lawful basis for collecting that data are listed below.
+
+| **Purpose/Activity** | **Type of data** | **Lawful basis for processing including basis of legitimate interest** |
+| --- | --- | --- |
+| To register you for our newsletter | (a) Contact | Performance of a contract with you |
+| To process your smart contract transactions | (a) Wallet address<br/>(b) Contact | (a) Performance of a contract with you<br/>(b) Necessary for our legitimate interests (to collect our fees) |
+| To manage our relationship with you which will include:<br/>(a) Notifying you about changes to our terms or privacy policy<br/>(b) Asking you to leave a review or take a survey | (a) Contact<br/>(b) Profile<br/>(c) Marketing and Communications | (a) Performance of a contract with you<br/>(b) Necessary to comply with a legal obligation<br/>(c) Necessary for our legitimate interests (to keep our records updated and to study how customers use our products/services) |
+| To administer and protect our business and this website (including troubleshooting, data analysis, testing, system maintenance, support, reporting and hosting of data) | (a) Contact<br/>(b) Technical | (a) Necessary for our legitimate interests (for running our business, provision of administration and IT services, network security, to prevent fraud and in the context of a business reorganisation or group restructuring exercise)<br/>(b) Necessary to comply with a legal obligation |
+| To use data analytics to improve our website, products/services, marketing,customer relationships and experiences | (a) Technical<br/>(b) Usage | Necessary for our legitimate interests (to define types of customers for our products and services, to keep our website updated and relevant, to develop our business and to inform our marketing strategy) |
+| To make suggestions and recommendations to you about goods or services that may be of interest to you | (a) Contact<br/>(b) Technical<br/>(c) Usage<br/>(d) Profile<br/>(e) Marketing and Communications | Necessary for our legitimate interests (to develop our products/services and grow our business) |
+
+- To carry out our obligations and enforce our rights.
+- In any other way we may describe when you provide the information.
+- For any other purpose with your consent.
+
+We may use information that is not personal information for any purpose. For example, we may aggregate usage data from many people in a way that does not identify any individuals to calculate the percentage of users accessing a feature on the website.
+
+## 8. Disclosure of Your Information <a id="DisclosureOfYourInfo"></a>
+
+We may share non-personal information without restriction. We may share your personal information with:
+
+- Any member of our corporate group, which means our subsidiaries, affiliates, our ultimate holding company and its subsidiaries, and affiliates.
+- To contractors, service providers, and other third parties we use to support our business.
+- If we offer a co-branded promotion, to our co-sponsor.
+- To fulfill the purpose for which you provide it.
+- For any other purposes that we disclose when you provide the information.
+- With your consent.
+
+We may also disclose your personal information:
+
+- To comply with any court order, law, or legal process, including responding to any government or regulatory request.
+- To enforce Terms of Use and other agreements including for billing and collections purposes.
+- To protect the rights, property, or safety of our business, our employees, our customers, or others. This includes exchanging information with other companies and organizations for the purposes of cybersecurity, fraud protection and credit risk reduction.
+- To investigate suspected violations of any law, rule or regulation, or the terms or policies for our website.
+
+## 9. Third Party Links <a id="ThirdPartyContent"></a>
+
+Some content or applications on our websites may be served by third parties, content providers and application providers including the following:
+
+  1. **Plugins.** Our website may make available the option for you to use &quot;plugins&quot; that are operated by social media companies. If you choose to use one of these plugins, then it may collect information about you and send it back to the social media company that owns it. This may happen even if you do not click on the plugin, if you are logged into the social media website that owns the plugin when you visit our website. Information collected by a plugin is subject to the privacy policy and terms of the social media company that makes it. If you do not want the social media company who owns a plugin to collect information about you when you visit our websites, sign out of the social media network before visiting. By interacting with a plugin when you are on our websites (for example, clicking the Facebook &quot;Like&quot; button), you are intentionally transferring information to that social media company. Further, if you are logged into a social media website when you visit our websites, then you are directing us to share your data with the social media company that owns the plugin.
+  2. **User Content.** Our websites may allow you to upload your own content to public areas of the website. Any information you submit becomes public information, and we do not control how others may use the content you submit. We are not responsible for uses that may violate our privacy policy, the law, or your intellectual property rights.
+  3. **Third-party links.** Our websites may contain links to other sites, which we do not control. Those websites have their own privacy policies and terms, and we encourage you to read those terms before interacting with third-party sites.
+
+## 10. Your Rights and Choices <a id="YourRightsAndChoices"></a>
+
+Your rights may vary depending on where you are located. We have created mechanisms to provide you with the following control over your information.
+
+- **Marketing**. If you do not want us to use your email address or other contact information to promote or recommend our own products and services, or third parties&#39; products or services, you can opt-out by checking the relevant box located on the form where we collect your contact information or, if presented with the option to opt-in, do not opt-in. You may also opt-out of further marketing communications by replying to any promotional email we have sent you or following the opt-out links on that message.
+- **Accessing, Updating and Deleting Your Information.** You can contact us as set forth in the _[Contact Us](#ContactUs)_ section below to request access to, correction of, or deletion of personal information that you have provided to us. We may not accommodate a request to change information if we believe the change would violate any law or legal requirement or negatively affect the information&#39;s accuracy. We cannot delete personal information, if any, that has been posted to the Ethereum blockchain through your use of a smart contract on our Network.
+- **Cookies and Automatic Data Collection Technologies**. You can set your browser to refuse all or some browser cookies, or to alert you when websites set or access cookies. However, if you disable or refuse cookies, please note that some parts of this website may become inaccessible or not function properly.
+- **California Residents**. If you are a California resident, you may have additional personal rights and choices with regard to your personal information. Please see _[Your California Privacy Rights](#YourCAPrivacyRights)_ for more information. California&#39;s &quot;Shine the Light&quot; law (Civil Code Section § 1798.83) permits users of our website that are California residents to request certain information regarding our disclosure of personal information to third parties for their direct marketing purposes. At this time, we do not engage in this type of disclosure.
+- **EU Residents.** If you are a resident of the European Union, you have the right to:
+  - request access to your personal data, commonly known as a &quot;data subject access request&quot;, which allows you to receive a copy of the personal data we hold about you and to check that we are lawfully processing it.
+  - Request a correction of the personal data that we hold about you. This enables you to have any incomplete or inaccurate data we hold about you corrected, though we may need to verify the accuracy of the new data you provide to us. You acknowledge we cannot correct data that has been posted to a public blockchain.
+  - Request erasure of your personal data. This enables you to ask us to delete or remove personal data where there is no good reason for us continuing to process it. You also have the right to ask us to delete or remove your personal data where you have successfully exercised your right to object to processing (see below), where we may have processed your information unlawfully or where we are required to erase your personal data to comply with local law. Note, however, that we may not always be able to comply with your request of erasure for specific legal reasons which will be notified to you, if applicable, at the time of your request. We cannot delete personal data that has been posted to a public blockchain.
+  - Object to processing of your personal data where we are relying on a legitimate interest (or those of a third party) and there is something about your particular situation which makes you want to object to processing on this ground as you feel it impacts on your fundamental rights and freedoms. In some cases, we may demonstrate that we have compelling legitimate grounds to process your information which override your rights and freedoms.
+  - Request restriction of processing of your personal data. This enables you to ask us to suspend the processing of your personal data in the following scenarios:
+    - If you want us to establish the data&#39;s accuracy.
+    - Where you need us to hold the data even if we no longer require it as you need it to establish, exercise or defend legal claims.
+    - You have objected to our use of your data but we need to verify whether we have overriding legitimate grounds to use it.
+  - Request the transfer of your personal data to you or to a third party. We will provide to you, or a third party you have chosen, your personal data in a structured, commonly used, machine-readable format. Note that this right only applies to automated information which you initially provided consent for us to use or where we used the information to perform a contract with you.
+  - Withdraw consent at any time where we are relying on consent to process your personal data. However, this will not affect the lawfulness of any processing carried out before you withdraw your consent. If you withdraw your consent, we may not be able to provide certain products or services to you. We will advise you if this is the case at the time you withdraw your consent. You acknowledge you cannot withdraw consent from participating in a smart contract that has already been executed.
+
+## 11. Data Security <a id="DataSecurity"></a>
+
+The security of your personal information is very important to us. We use physical, electronic, and administrative safeguards designed to protect your personal information from loss, misuse and unauthorized access, use, alteration or disclosure. We will only retain your personal information for as long as reasonably necessary to fulfil the purpose of collecting it.
+
+The safety and security of your information also depends on you. You are responsible for keeping your wallet address and your personal information confidential. We ask you not to share your wallet&#39;s private key with anyone. We urge you to take care when providing information to social media accounts or message boards, which any website visitor can view.
+
+## 12. Your California Privacy Rights <a id="YourCaliforniaPrivacyRights"></a>
+
+If you are a California resident, California law may provide you with additional rights regarding our use of your personal information. To learn more about your California privacy rights, you can view our [Privacy Notice for California Residents](/california-privacy-notice).
+
+## 13. Changes to Our Privacy Policy <a id="ChangesToOurPrivacyPolicy"></a>
+
+We will post any changes we may make to our privacy policy on this page. If the changes materially alter how we use or treat your information we will notify you through a notice on the website home page. The date the privacy policy was last revised is identified at the top of the page.
+
+## 14. Contact Us <a id="ContactUs"></a>
+
+If you have any comments or questions about our privacy policy, please contact our data privacy manager at [legal@keep.network](mailto:legal@keep.network).

--- a/src/pages/terms-of-use/index.de.md
+++ b/src/pages/terms-of-use/index.de.md
@@ -1,0 +1,204 @@
+---
+template: legal-page
+path: /terms-of-use
+title: tBTC Network Terms of Use
+---
+Last Modified: May 1, 2020
+
+## Acceptance of the Terms of Use
+
+These terms of use are entered into by and between You and Keep SECZ, a Cayman Islands special economic zone company ("**Company**", "**we**" or "**us**"). The following terms and conditions, together with any documents they expressly incorporate by reference (collectively, these "**Terms of Use**"), govern your access to and use of the network located at [tbtc.network](https://tbtc.network/) as well as any content, functionality, smart contracts, distributed applications ("Dapps") and services offered on or through the tBTC network (collectively, the "**Network**"). The Network is currently administered by the Company using open source protocols; however, we intend over time for the Network and the network protocol to become decentralized and governed entirely by the community of its users in whatever manner they determine.
+
+Please read the Terms of Use carefully before you start to use the Network. **By using the Network or by clicking to accept or agree to the Terms of Use when this option is made available to you, you accept and agree to be bound and abide by these Terms of Use and our [Privacy Policy](/privacy-policy), incorporated herein by reference.** If you do not want to agree to these Terms of Use or the [Privacy Policy](/privacy-policy), you must not access or use the Network.
+
+This Network is offered and available to users who are 18 years of age or older who are not residents of countries named on the [US Department of the Treasury Sanctions list](https://www.treasury.gov/resource-center/sanctions/Programs/Pages/Programs.aspx) or named on the Office of Foreign Asset Control's list of [Specially Designated Nationals and Blocked Persons](https://www.treasury.gov/resource-center/sanctions/SDN-List/Pages/default.aspx) ("SDN List"). If the user is an organization, you affirm you have the right, power and authority to enter into this agreement on behalf of the organization and bind the organization to its terms. If you do not agree to the terms of this agreement, you must not use the Network or any of our services. By using this Network, you represent and warrant that you are of legal age to form a binding contract with the Company and meet all of the foregoing eligibility requirements. You represent that you are legally permitted to use the Network in your jurisdiction including owning Digital Assets and interacting with the Network in any way.If you do not meet all of these requirements, you must not access or use the Network. Without limiting the foregoing, by using the Network, you acknowledge and understand that laws regarding financial instruments, which sometimes include cryptographic tokens, also known as "**Digital Assets**", and decentralized finance may vary from jurisdiction to jurisdiction, and it is your obligation alone to ensure that you fully comply with any law, regulation or directive, relevant to your jurisdiction with regard to the use of the Network. You further represent and warrant that you will not use the Network or access its smart contract functionality if the laws of your country of residency or establishment prohibit you from doing so in accordance with this agreement. For the avoidance of doubt, the ability to access the Network does not necessarily mean that the Network, or your activities through it, are legal under the laws, regulations or directives relevant to your jurisdiction. All of the Network or the services made available through the Network may not be available to all users, and we reserve the right to assess or reassess at any time your eligibility to use all or part of our Network. The availability of the Network does not constitute, and may not be used for the purposes of, an offer or solicitation to anyone in any jurisdiction in which such offer or solicitation is not authorized, or to any person to whom it is unlawful to make such an offer or solicitation. By accessing or using the Network, you explicitly agree that the smart contracts built into the Dapps that comprise the Network are legally binding and enforceable upon you and the contract counterparty.
+
+## Changes to the Terms of Use
+
+We, or in the future, a decentralized governing body, may revise and update these Terms of Use from time to time in our sole discretion. All changes are effective immediately when we post them and apply to all access to and use of the Network thereafter. However, any changes to the dispute resolution provisions set forth in Governing Law and Jurisdiction will not apply to any disputes for which the parties have actual notice on or prior to the date the change is posted on the Network.
+
+Your continued use of the Network following the posting of revised Terms of Use means that you accept and agree to the changes. You are expected to check this page each time you access this Network so you are aware of any changes, as they are binding on you.
+
+## Accessing the Network and Account Security
+
+To access the Network or some of the resources it offers, you may be asked to provide an Ethereum wallet address (a "**Wallet**"). It is your sole responsibility to maintain the security of your Wallet. If you lose access to your Wallet, a private key, password, or other method of securing your Wallet, any funds may be irretrievable, and we will be unable to assist you in any way. You hereby irrevocably waive, release and discharge all claims, whether known or unknown to you, against us, our affiliates and their respective shareholders, members, directors, officers, employees, agents and representatives related to your use of any Wallet software, associated loss of funds, transaction failures, or any other defects that arise in the course of your use of your Wallet, including any losses that may obtain as a result of any failure in smart contracts made available on the Network. By using the Network, you agree to be fully, independently and personally liable for each transaction made on the Network by you, and you must make sure that you are the only person with access to your Wallet at all times. You hereby accept responsibility for any activity transacted on the Network through your Wallet.
+
+We will use commercially reasonable technical and physical safeguards to make the Network securely available to its users. However, given the inherent risk of transmitting information over the internet and the relatively new and untested nature of decentralized finance, we will not be liable if for any reason all or any part of the Network is unavailable at any time or for any period. You alone are responsible for evaluating any code provided by or used on the Network. From time to time, we may restrict access to some parts of the Network, or the entire Network, to users. You are responsible for making all arrangements necessary for you to have access to the Network and ensuring that all persons who access the Network through your internet connection are aware of these Terms of Use and comply with them.
+
+It is a condition of your use of the Network that all the information you provide on the Network is correct, current and complete. You agree that all information you provide to this Network or otherwise, including but not limited to through the use of any interactive features on the Network, is governed by our [_Privacy Policy_](https://tbtc.network/privacy-policy), and you consent to all actions we take with respect to your information consistent with our Privacy Policy.
+
+## Fees
+
+Some services on the Network involve the use of blockchains, including the Ethereum blockchain, which may require that you pay a fee, such as "**Ethereum Gas Charges**", for the computational resources required to perform a transaction. You acknowledge and agree that the Company has no control over these fees, including: 
+
+- (a) any Ethereum blockchain transactions;
+- (b) the method of payment of any Ethereum Gas Charges; or 
+- (c) any actual payments of Ethereum Gas Charges.
+
+Accordingly, you must ensure that you have a sufficient balance of digital assets, such as Ether, stored at your Wallet to complete any transaction on the Ethereum blockchain network before initiating such transactions. You may be subject to additional fees and charges, including fees required to access certain smart contracts. You acknowledge that such fees may be adjusted from time to time by us or by other users who set the terms of their own smart contracts. If you do not agree with the fees charged for Network functionality, do not use or access the Network.
+
+The use of certain smart contract functionality on the Network may require the purchase of Keep Digital Assets, the payment of fees or the posting of collateral in other types of Digital Assets as determined by the creator of such smart contract. You agree that any such fees or requirements are reasonable, and your use of the Network or any related smart contracts shall constitute your acceptance of such fees or requirements.
+
+Notwithstanding anything in this Agreement to the contrary, it is your sole responsibility to determine whether, and to what extent, any taxes apply to any transactions you conduct through the Network, and to withhold, collect, report and remit the correct amount of taxes to the appropriate tax authorities. You agree to indemnify and hold us harmless for your failure to pay any taxes, including any penalties, duties and interest, imposed by any governmental authority.
+
+**Risks.** Use of the Network may carry financial risk. Digital Assets are a novel and relatively experimental technology. Their value, if any, can fluctuate with great volatility, and transactions conducted with Digital Assets are irreversible. The use of Digital Assets in decentralized finance is inherently risky, and you acknowledge and agree that you are accessing and using the Network at your own risk. The risk of loss due to market volatility and malfeasance by other users of the Network can be substantial. Digital Assets and smart contracts are typically described using extremely technical language that is difficult to understand and requires a deep knowledge of cryptography and computer science. Dapps made available on the Network may have inherent design flaws that have not been detected in testing or may not perform as expected in conjunction with third-party technology or high-volume use. You should carefully consider whether you have sufficient understanding of the technology before accessing or using the Network.
+
+By accessing or using the Network, you hereby represent that you have the requisite knowledge and experience to evaluate the risk of the technology you are using and any transactions you undertake, and you accept the risk that the Network might not function as anticipated and that you might lose access to your Digital Assets temporarily or permanently. The Network encourages the creation of third-party Dapps and smart contract technology, but the availability of third-party Dapps and smart contract technology on the Network is not an endorsement by us of that technology. You acknowledge and agree that the Company is not a party to the smart contracts offered on the Network and that the contract counterparty to any smart contracts you enter will likely be unknown to you.
+
+You acknowledge that the Network runs on top of the decentralized Ethereum blockchain and that we have no control over the availability of the Ethereum blockchain or the price of the Digital Asset, ETH. The Ethereum protocol is open source, and anyone can use, copy or make modifications to the protocol known as "**Forks**"which could materially affect the operation of the Ethereum blockchain and thus, the Network. In the event of a Fork, you acknowledge and agree that we may temporarily or permanently suspend our operations and that we bear no liability for losses resulting from a Fork in the Ethereum blockchain.
+
+More specifically, if you are a user of any one of several smart contracts on the Network, you may be required to post collateral or pay a fee. You acknowledge that under certain circumstances, market fluctuation could require you to increase the amount of collateral required to fulfill your performance obligations under the smart contract or your collateral could diminish in value or be lost altogether. Under no circumstances will the operation of all or any portion of the Network be deemed to create a relationship that includes the provision or tendering of investment advice.
+
+The Network may become the target of sophisticated hacking attempts, cyber attacks, dramatic fluctuations in use or other technical or operational challenges that could affect its availability or ability to function properly. You accept the risk of any delays or transaction failures resulting from such interference with the Network or any third-party services connected to or operating in conjunction with the Network including other operators of decentralized networks, platforms or Dapps. You further acknowledge that decentralized lending and borrowing protocols that ultimately allow the use of Digital Assets created on our platform have no legal obligation to provide software development to or maintain their protocols, and you should not expect that their services will continue or be available at any particular time. We are not responsible for the availability of or maintenance to lending or borrowing protocols that allow interaction, through smart contracts or otherwise, with the Keep Network or Keep Digital Assets.
+
+You acknowledge that Company is a non-custodial provider of Network services. We do not provide custody services, control or manage your Digital Assets in any manner whatsoever. The Network exists in a decentralized environment through which functionality can be autonomously directly accessed by you without any involvement or actions by Company or any third-party. Use of the Network requires the use of ERC 20 compatible Wallet(s). It is your responsibility to maintain access to and the security of your Wallet. If you fail to secure your Wallet properly, you could lose access to the contents of your Wallet and you will no longer be able to access or use some Network features.
+
+In many jurisdictions, the regulatory frameworks imposed by governmental authorities over the use and sale of cryptocurrencies or Digital Assets are uncertain. Changes in regulations and policies may affect your use of the Network in your jurisdiction, and you are responsible for consulting with legal counsel and complying with all applicable laws in your jurisdiction.
+
+The Network may rely on the use of third-party platforms, exchanges, Dapps, oracles or other mechanisms to facilitate your use of the Network. We do not control the availability of those platforms, and your access to and use of the Network could be affected by changes in those platforms which are beyond our control.
+
+## Intellectual Property Rights
+
+You must not delete or alter any copyright, trademark or other proprietary rights notices from copies of materials from this site. The smart contracts and software provided by us to the Network are made available to you under the [MIT open source license](https://github.com/keep-network/keep-ecdsa/blob/master/LICENSE), and the documentation and source code are available at [https://github.com/keep-network](https://github.com/keep-network). Other third-party technology provided to the Network is owned by the third-party provider of such technology or is made available subject to the license identified with the technology.
+
+The Keep name, Company logo and other related trademarks or service marks are the exclusive property of the Company and may not be used without our prior written consent. If you breach these Terms of Use, your right to use the Network will cease immediately and you must, at our option, return or destroy any copies of the materials you have made. No right, title or interest in or to the Network or any content on the Network is transferred to you, and all rights not expressly granted are reserved by the Company. Any use of the Network not expressly permitted by these Terms of Use is a breach of these Terms of Use and may violate copyright, trademark and other laws.
+
+## Prohibited Uses
+
+You may use the Network only for lawful purposes and in accordance with these Terms of Use. You agree not to use the Network:
+
+- In any way that violates any applicable federal, state, local or international law or regulation (including, without limitation, any laws regarding the export of data or software to and from the US or other countries).
+- For the purpose of exploiting, harming or attempting to exploit or harm minors in any way by exposing them to inappropriate content, asking for personally identifiable information or otherwise.
+- To attempt to circumvent any Network security or access controls or to interfere with the operation of the Network.
+- To impersonate or attempt to impersonate the Company, a Company employee, another user or any other person or entity (including, without limitation, by using e-mail addresses or wallet addresses associated with any of the foregoing).
+- To transmit or exchange Digital Assets that are the direct or indirect proceeds of any illegal, criminal or fraudulent behavior including terrorism.
+- In any manner that could disable, overburden, damage, or impair the site or interfere with any other party's use of the Network, including their ability to engage in real time activities through the Network.
+- Use any robot, spider or other automatic device, process or means to access the Network for any purpose, including monitoring or copying any of the material on the Network.
+- Use any manual process to monitor or copy any of the material on the Network or for any other unauthorized purpose without our prior written consent.
+- Use any device, software or routine that interferes with the proper working of the Network.
+- Introduce any viruses, trojan horses, worms, logic bombs or other material which is malicious or technologically harmful.
+- Otherwise attempt to interfere with the proper working of the Network.
+
+## User Contributions
+
+The Network may contain links to social media, message boards, chat rooms, personal web pages or profiles, forums, bulletin boards, FAQs and other interactive features (collectively, "**Interactive Services**") that allow users to post, submit, publish, display, advise or transmit to other users or other persons (hereinafter, "**post**") content or materials (collectively, "**User Contributions**") on or through the Network.
+
+All User Contributions must comply with the Content Standards set out in these Terms of Use. Any User Contribution you post to the site will be considered non-confidential and non-proprietary. By providing any User Contribution on the Network, you grant us and our affiliates and service providers, and each of their and our respective licensees, successors and assigns the right to use, reproduce, modify, perform, display, distribute and otherwise disclose to third parties any such material for any purpose.
+
+You represent and warrant that:
+
+- You own or control all rights in and to the User Contributions and have the right to grant the license granted above to us and our affiliates and service providers, and each of their and our respective licensees, successors and assigns.
+- All of your User Contributions do and will comply with these Terms of Use.
+
+You understand and acknowledge that you are responsible for any User Contributions you submit or contribute, and you, not the Company, have fully responsibility for such content, including its legality, reliability, accuracy and appropriateness. We are not responsible, or liable to any third party, for the content or accuracy of any User Contributions posted by you or any other user of the Network.
+
+## Monitoring and Enforcement; Termination
+
+We have the right to:
+
+- Remove or refuse to post any User Contributions for any or no reason in our sole discretion.
+- Take any action with respect to any User Contribution that we deem necessary or appropriate in our sole discretion, including if we believe that such User Contribution violates the Terms of Use, including the Content Standards, infringes any intellectual property right or other right of any person or entity, threatens the personal safety of users of the Network or the public or could create liability for the Company.
+- Disclose information about you to any third party who claims that material posted by you violates their rights, including their intellectual property rights or their right to privacy.
+- Take appropriate legal action, including without limitation, referral to law enforcement, for any illegal or unauthorized use of the Network.
+- Terminate or suspend your access to all or part of the Network for any or no reason, including without limitation, any violation of these Terms of Use.
+
+Without limiting the foregoing, we have the right to fully cooperate with any law enforcement authorities or court order requesting or directing us to disclose the identity or other information of anyone using or posting any materials on or through the Network.
+
+However, we do not undertake to review material before it is posted on or through the Network and cannot ensure prompt removal of objectionable material after it has been posted. Accordingly, we assume no liability for any action or inaction regarding transmissions, communications or content provided by any user or third party. We have no liability or responsibility to anyone for performance or nonperformance of the activities described in this section.
+
+## Content Standards
+
+These content standards apply to any and all User Contributions and use of Interactive Services. User Contributions must in their entirety comply with all applicable federal, state, local and international laws and regulations. Without limiting the foregoing, User Contributions must not:
+
+- Contain any material which is defamatory, obscene, indecent, abusive, offensive, harassing, violent, hateful, inflammatory or otherwise objectionable.
+- Promote sexually explicit or pornographic material, violence, or discrimination based on race, sex, religion, nationality, disability, sexual orientation or age.
+- Infringe any patent, trademark, trade secret, copyright or other intellectual property or other rights of any other person.
+- Violate the legal rights (including the rights of publicity and privacy) of others or contain any material that could give rise to any civil or criminal liability under applicable laws or regulations or that otherwise may be in conflict with these Terms of Use and our [Privacy Policy](https://tbtc.network/privacy-policy).
+- Be likely to deceive any person.
+- Promote any illegal activity, or advocate, promote or assist any unlawful act.
+- Cause annoyance, inconvenience or needless anxiety or be likely to upset, embarrass, alarm or annoy any other person.
+- Impersonate any person or misrepresent your identity or affiliation with any person or organization.
+- Involve commercial activities or sales, such as contests, sweepstakes and other sales promotions, barter or advertising.
+- Give the impression that they emanate from or are endorsed by us or any other person or entity, if this is not the case.
+
+## Reliance on Information Posted
+
+The information presented on or through the Network is made available solely for general information purposes. We do not warrant the accuracy, completeness or usefulness of this information. Any reliance you place on such information is strictly at your own risk. We disclaim all liability and responsibility arising from any reliance placed on such materials by you or any other user of the Network, or by anyone who may be informed of any of its contents.
+
+This Network may include or link to content provided by third parties, including materials provided by other users, smart contract creators, third-party licensors, syndicators, aggregators, reporting services, FAQ providers and/or "how to"manuals. All statements and/or opinions expressed in such materials, and all articles and responses to questions and other content, other than the content provided by the Company, are solely the opinions and the responsibility of the person or entity providing those materials. These materials do not necessarily reflect the opinion of the Company. We are not responsible, or liable to you or any third party, for the content or accuracy of any materials provided by any third parties.
+
+## Changes to the Network
+
+We may update the content on this Network from time to time, but its content is not necessarily complete or up-to-date. We reserve the right to withdraw or amend this Network, and any service or functionality, including smart contract functionality, on the Network in our sole discretion without notice. Any of the material on the Network may be out of date at any given time, and we are under no obligation to update such material. You acknowledge that the software protocols comprising the Network are open source, and over time, by consensus of Network users or by actions of third parties beyond our controls, may be modified, copied or reproduced in different form. As such we are not responsible for the operation of the underlying protocols and make no guarantee of their functionality, security or availability. In the event of a change in the operation of the Network, you agree we may temporarily or permanently suspend our operations without liability to you.
+
+## Information About You and Your Visits to the Network
+
+All information we collect on this Network is subject to our Privacy Policy. By using the Network, you consent to all actions taken by us with respect to your information in compliance with the Privacy Policy.
+
+## Third-Party Terms and Conditions
+
+Additional terms and conditions may apply to specific portions, services or features of the Network provided by third parties including Dapps and smart contracts, either alone or in conjunction with the functionality provided by us. The use of such services or features shall be governed by the terms of use associated with them, and all such additional terms of use are hereby incorporated by this reference into these Terms of Use. We accept no liability or responsibility for any third-party functionality or any of our open source functionality that has been modified by third parties.
+
+## Links from the Network
+
+If the Network contains links to other sites and resources provided by third parties, these links are provided for your convenience only. We have no control over the contents of those sites or resources and accept no responsibility for them or for any loss or damage that may arise from your use of them. If you decide to access any of the third party sites linked to this Network, you do so entirely at your own risk and subject to the terms and conditions of use for such Networks.
+
+## Geographic Restrictions
+
+Access to the Network may not be legal by certain persons or in certain countries. You are responsible for compliance with all applicable laws in your jurisdiction.
+
+## Disclaimer of Warranties
+
+WE WILL NOT BE LIABLE FOR ANY LOSS OR DAMAGE CAUSED BY A DISTRIBUTED DENIAL-OF-SERVICE ATTACK, HACKS, VIRUSES OR OTHER TECHNOLOGICALLY HARMFUL MATERIAL THAT MAY INFECT YOUR COMPUTER EQUIPMENT, COMPUTER PROGRAMS, DATA OR OTHER PROPRIETARY MATERIAL DUE TO YOUR USE OF THE NETWORK OR ANY SERVICES OR ITEMS OBTAINED THROUGH THE NETWORK, ANY THIRD PARTY LINKS (INCLUDING BUT NOT LIMITED TO SMART CONTRACTS FAQS OR OTHER MATERIALS) ACCESSED THROUGH OR IN CONJUNCTION WITH THE NETWORK, OR ON ANY NETWORK LINKED TO IT.
+
+YOUR USE OF THE NETWORK, ITS CONTENT AND ANY SERVICES OR ITEMS OBTAINED THROUGH THE NETWORK IS AT YOUR OWN RISK. THE NETWORK, ITS CONTENT AND ANY SERVICES OR ITEMS OBTAINED THROUGH THE NETWORK ARE PROVIDED ON AN "AS IS"AND "AS AVAILABLE"BASIS, WITHOUT ANY WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED. NEITHER THE COMPANY NOR ANY PERSON ASSOCIATED WITH THE COMPANY MAKES ANY WARRANTY OR REPRESENTATION WITH RESPECT TO THE COMPLETENESS, SECURITY, RELIABILITY, QUALITY, ACCURACY OR AVAILABILITY OF THE NETWORK. WITHOUT LIMITING THE FOREGOING, NEITHER THE COMPANY NOR ANYONE ASSOCIATED WITH THE COMPANY REPRESENTS OR WARRANTS THAT THE NETWORK, ITS CONTENT OR ANY SERVICES OR ITEMS OBTAINED THROUGH THE NETWORK WILL BE ACCURATE, RELIABLE, ERROR-FREE OR UNINTERRUPTED, THAT DEFECTS WILL BE CORRECTED, THAT OUR SITE OR THE SERVER THAT MAKES IT AVAILABLE ARE FREE OF VIRUSES OR OTHER HARMFUL COMPONENTS OR THAT THE NETWORK OR ANY SERVICES OR ITEMS OBTAINED THROUGH THE NETWORK WILL OTHERWISE MEET YOUR NEEDS OR EXPECTATIONS.
+
+YOU HEREBY IRREVOCABLY WAIVE, RELEASE AND DISCHARGE ALL CLAIMS, WHETHER KNOWN OR UNKNOWN TO YOU, AGAINST US, OUR AFFILIATES AND THEIR RESPECTIVE SHAREHOLDERS, MEMBERS, DIRECTORS, OFFICERS, EMPLOYEES, AGENTS AND REPRESENTATIVES RELATED TO YOUR USE OF ANY WALLET SOFTWARE, ASSOCIATED LOSS OF FUNDS, TRANSACTION FAILURES, OR ANY OTHER DEFECTS THAT ARISE IN THE COURSE OF YOUR USE OF YOUR WALLET. THE COMPANY HEREBY DISCLAIMS ALL WARRANTIES OF ANY KIND, WHETHER EXPRESS OR IMPLIED, STATUTORY OR OTHERWISE, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF MERCHANTABILITY, NON-INFRINGEMENT AND FITNESS FOR PARTICULAR PURPOSE.
+
+THE FOREGOING DOES NOT AFFECT ANY WARRANTIES WHICH CANNOT BE EXCLUDED OR LIMITED UNDER APPLICABLE LAW.
+
+## Limitation on Liability
+
+IN NO EVENT WILL THE COMPANY, ITS AFFILIATES OR THEIR LICENSORS, SERVICE PROVIDERS, EMPLOYEES, AGENTS, OFFICERS OR DIRECTORS BE LIABLE FOR DAMAGES OF ANY KIND, UNDER ANY LEGAL THEORY, ARISING OUT OF OR IN CONNECTION WITH YOUR USE, OR INABILITY TO USE, THE NETWORK, ANY NETWORKS LINKED TO IT, ANY SMART CONTRACTS OR DISTRIBUTED APPLICATIONS EXISTING ON OR CONNECTING TO THE NETWORK, ANY LOSS OF FUNDS OR COLLATERAL, ANY CONTENT ON THE NETWORK OR SUCH OTHER NETWORKS OR ANY SERVICES OR ITEMS OBTAINED THROUGH THE NETWORK OR SUCH OTHER NETWORKS, INCLUDING ANY DIRECT, INDIRECT, SPECIAL, INCIDENTAL, CONSEQUENTIAL OR PUNITIVE DAMAGES, INCLUDING BUT NOT LIMITED TO, PERSONAL INJURY, PAIN AND SUFFERING, EMOTIONAL DISTRESS, LOSS OF REVENUE, LOSS OF PROFITS, LOSS OF BUSINESS OR ANTICIPATED SAVINGS, LOSS OF USE, LOSS OF GOODWILL, LOSS OF DATA, AND WHETHER CAUSED BY TORT (INCLUDING NEGLIGENCE), BREACH OF CONTRACT OR OTHERWISE, EVEN IF FORESEEABLE. UNDER NO CIRCUMSTANCES WILL WE BE RESPONSIBLE FOR ANY DAMAGES, LOSS OR INJURY RESULTING FROM HACKING, TAMPERING OR OTHER UNAUTHORIZED ACCESS OR USE OF THE NETWORK OR ITS CONTENTS.
+
+THE FOREGOING DOES NOT AFFECT ANY LIABILITY WHICH CANNOT BE EXCLUDED OR LIMITED UNDER APPLICABLE LAW.
+
+## Indemnification
+
+You agree to defend, indemnify and hold harmless the Company, its affiliates, licensors and service providers, and its and their respective officers, directors, employees, contractors, agents, licensors, suppliers, successors and assigns from and against any claims, liabilities, damages, judgments, awards, losses, costs, expenses, debts and fees (including reasonable attorneys' fees) arising out of or relating to: your use of or access to the Network; your violation of any third party right; the provision by you of any false or misleading information; your violation of any law, rule or regulation; your violation of these Terms of Use; your willful misconduct; or your use of the Network, including, but not limited to, your User Contributions, any use of the Network's content, services and products other than as expressly authorized in these Terms of Use or your use of any information obtained from the Network.
+
+## Release of Claims
+
+You acknowledge that the Network (including without limitation the smart contracts) and your use of the Network contain certain risks, including without limitation the following risks:  any smart contracts you interact with are entirely your own responsibility and your own liability, and we are not a party to the smart contracts; At any time, your access to your Digital Assets may be suspended or terminated or there may be a delay in your access or use of your Digital Assets which may result in the Digital Assets diminishing in value or you being unable to complete a smart contract; if your collateral declines such that your collateral is no longer sufficient to secure your position as a signer or depositor that a liquidation auction may not produce sufficient revenue to return your collateral, or other users may seize your collateral to close out your account; and the Network and related smart contracts may be suspended or terminated for any or no reason, which may limit your access to your Digital Assets. You assume all risk in connection with your access to and use of the Network and its smart contracts, and you waive and release us from any and all liability, claims, causes of action or damages arising from or in any way related to your use of the Network or the smart contracts.
+
+## Governing Law and Jurisdiction
+
+All matters relating to the Network and these Terms of Use and any dispute or claim arising therefrom or related thereto (in each case, including non-contractual disputes or claims), shall be governed by and construed in accordance with the internal laws of the Cayman Islands without giving effect to any choice or conflict of law provision or rule.
+
+Any legal suit, action or proceeding arising out of, or related to, these Terms of Use or the Network shall be instituted exclusively in the courts of the Cayman Islands. You waive any and all objections to the exercise of jurisdiction over you by such courts and to venue in such courts.
+
+## Arbitration
+
+At Company's sole discretion, it may require You to submit any disputes arising from the use of these Terms of Use or the Network, including disputes arising from or concerning their interpretation, violation, invalidity, non-performance, or termination, to final and binding arbitration under the Rules of Arbitration of the American Arbitration Association applying Cayman Island law.
+
+## Limitation on Time to File Claims
+
+ANY CAUSE OF ACTION OR CLAIM YOU MAY HAVE ARISING OUT OF OR RELATING TO THESE TERMS OF USE OR THE NETWORK MUST BE COMMENCED WITHIN ONE (1) YEAR AFTER THE CAUSE OF ACTION ACCRUES, OTHERWISE, SUCH CAUSE OF ACTION OR CLAIM IS PERMANENTLY BARRED.
+
+## Waiver and Severability
+
+No waiver of by the Company of any term or condition set forth in these Terms of Use shall be deemed a further or continuing waiver of such term or condition or a waiver of any other term or condition, and any failure of the Company to assert a right or provision under these Terms of Use shall not constitute a waiver of such right or provision.
+
+If any provision of these Terms of Use is held by a court or other tribunal of competent jurisdiction to be invalid, illegal or unenforceable for any reason, such provision shall be eliminated or limited to the minimum extent such that the remaining provisions of the Terms of Use will continue in full force and effect.
+
+## Entire Agreement
+
+The Terms of Use and our Privacy Policy constitute the sole and entire agreement between you and Keep SECZ with respect to the Network and supersede all prior and contemporaneous understandings, agreements, representations and warranties, both written and oral, with respect to the Network.
+
+## Your Comments and Concerns
+
+This Network is initially operated by Keep SEZC.
+
+All feedback, comments, requests for technical support and other communications relating to the Network should be directed to: [legal@keep.network](mailto:legal@keep.network).
+
+0142785.0724991 4828-0651-3078v3

--- a/src/pages/terms-of-use/index.es.md
+++ b/src/pages/terms-of-use/index.es.md
@@ -1,0 +1,204 @@
+---
+template: legal-page
+path: /terms-of-use
+title: tBTC Network Terms of Use
+---
+Last Modified: May 1, 2020
+
+## Acceptance of the Terms of Use
+
+These terms of use are entered into by and between You and Keep SECZ, a Cayman Islands special economic zone company ("**Company**", "**we**" or "**us**"). The following terms and conditions, together with any documents they expressly incorporate by reference (collectively, these "**Terms of Use**"), govern your access to and use of the network located at [tbtc.network](https://tbtc.network/) as well as any content, functionality, smart contracts, distributed applications ("Dapps") and services offered on or through the tBTC network (collectively, the "**Network**"). The Network is currently administered by the Company using open source protocols; however, we intend over time for the Network and the network protocol to become decentralized and governed entirely by the community of its users in whatever manner they determine.
+
+Please read the Terms of Use carefully before you start to use the Network. **By using the Network or by clicking to accept or agree to the Terms of Use when this option is made available to you, you accept and agree to be bound and abide by these Terms of Use and our [Privacy Policy](/privacy-policy), incorporated herein by reference.** If you do not want to agree to these Terms of Use or the [Privacy Policy](/privacy-policy), you must not access or use the Network.
+
+This Network is offered and available to users who are 18 years of age or older who are not residents of countries named on the [US Department of the Treasury Sanctions list](https://www.treasury.gov/resource-center/sanctions/Programs/Pages/Programs.aspx) or named on the Office of Foreign Asset Control's list of [Specially Designated Nationals and Blocked Persons](https://www.treasury.gov/resource-center/sanctions/SDN-List/Pages/default.aspx) ("SDN List"). If the user is an organization, you affirm you have the right, power and authority to enter into this agreement on behalf of the organization and bind the organization to its terms. If you do not agree to the terms of this agreement, you must not use the Network or any of our services. By using this Network, you represent and warrant that you are of legal age to form a binding contract with the Company and meet all of the foregoing eligibility requirements. You represent that you are legally permitted to use the Network in your jurisdiction including owning Digital Assets and interacting with the Network in any way.If you do not meet all of these requirements, you must not access or use the Network. Without limiting the foregoing, by using the Network, you acknowledge and understand that laws regarding financial instruments, which sometimes include cryptographic tokens, also known as "**Digital Assets**", and decentralized finance may vary from jurisdiction to jurisdiction, and it is your obligation alone to ensure that you fully comply with any law, regulation or directive, relevant to your jurisdiction with regard to the use of the Network. You further represent and warrant that you will not use the Network or access its smart contract functionality if the laws of your country of residency or establishment prohibit you from doing so in accordance with this agreement. For the avoidance of doubt, the ability to access the Network does not necessarily mean that the Network, or your activities through it, are legal under the laws, regulations or directives relevant to your jurisdiction. All of the Network or the services made available through the Network may not be available to all users, and we reserve the right to assess or reassess at any time your eligibility to use all or part of our Network. The availability of the Network does not constitute, and may not be used for the purposes of, an offer or solicitation to anyone in any jurisdiction in which such offer or solicitation is not authorized, or to any person to whom it is unlawful to make such an offer or solicitation. By accessing or using the Network, you explicitly agree that the smart contracts built into the Dapps that comprise the Network are legally binding and enforceable upon you and the contract counterparty.
+
+## Changes to the Terms of Use
+
+We, or in the future, a decentralized governing body, may revise and update these Terms of Use from time to time in our sole discretion. All changes are effective immediately when we post them and apply to all access to and use of the Network thereafter. However, any changes to the dispute resolution provisions set forth in Governing Law and Jurisdiction will not apply to any disputes for which the parties have actual notice on or prior to the date the change is posted on the Network.
+
+Your continued use of the Network following the posting of revised Terms of Use means that you accept and agree to the changes. You are expected to check this page each time you access this Network so you are aware of any changes, as they are binding on you.
+
+## Accessing the Network and Account Security
+
+To access the Network or some of the resources it offers, you may be asked to provide an Ethereum wallet address (a "**Wallet**"). It is your sole responsibility to maintain the security of your Wallet. If you lose access to your Wallet, a private key, password, or other method of securing your Wallet, any funds may be irretrievable, and we will be unable to assist you in any way. You hereby irrevocably waive, release and discharge all claims, whether known or unknown to you, against us, our affiliates and their respective shareholders, members, directors, officers, employees, agents and representatives related to your use of any Wallet software, associated loss of funds, transaction failures, or any other defects that arise in the course of your use of your Wallet, including any losses that may obtain as a result of any failure in smart contracts made available on the Network. By using the Network, you agree to be fully, independently and personally liable for each transaction made on the Network by you, and you must make sure that you are the only person with access to your Wallet at all times. You hereby accept responsibility for any activity transacted on the Network through your Wallet.
+
+We will use commercially reasonable technical and physical safeguards to make the Network securely available to its users. However, given the inherent risk of transmitting information over the internet and the relatively new and untested nature of decentralized finance, we will not be liable if for any reason all or any part of the Network is unavailable at any time or for any period. You alone are responsible for evaluating any code provided by or used on the Network. From time to time, we may restrict access to some parts of the Network, or the entire Network, to users. You are responsible for making all arrangements necessary for you to have access to the Network and ensuring that all persons who access the Network through your internet connection are aware of these Terms of Use and comply with them.
+
+It is a condition of your use of the Network that all the information you provide on the Network is correct, current and complete. You agree that all information you provide to this Network or otherwise, including but not limited to through the use of any interactive features on the Network, is governed by our [_Privacy Policy_](https://tbtc.network/privacy-policy), and you consent to all actions we take with respect to your information consistent with our Privacy Policy.
+
+## Fees
+
+Some services on the Network involve the use of blockchains, including the Ethereum blockchain, which may require that you pay a fee, such as "**Ethereum Gas Charges**", for the computational resources required to perform a transaction. You acknowledge and agree that the Company has no control over these fees, including: 
+
+- (a) any Ethereum blockchain transactions;
+- (b) the method of payment of any Ethereum Gas Charges; or 
+- (c) any actual payments of Ethereum Gas Charges.
+
+Accordingly, you must ensure that you have a sufficient balance of digital assets, such as Ether, stored at your Wallet to complete any transaction on the Ethereum blockchain network before initiating such transactions. You may be subject to additional fees and charges, including fees required to access certain smart contracts. You acknowledge that such fees may be adjusted from time to time by us or by other users who set the terms of their own smart contracts. If you do not agree with the fees charged for Network functionality, do not use or access the Network.
+
+The use of certain smart contract functionality on the Network may require the purchase of Keep Digital Assets, the payment of fees or the posting of collateral in other types of Digital Assets as determined by the creator of such smart contract. You agree that any such fees or requirements are reasonable, and your use of the Network or any related smart contracts shall constitute your acceptance of such fees or requirements.
+
+Notwithstanding anything in this Agreement to the contrary, it is your sole responsibility to determine whether, and to what extent, any taxes apply to any transactions you conduct through the Network, and to withhold, collect, report and remit the correct amount of taxes to the appropriate tax authorities. You agree to indemnify and hold us harmless for your failure to pay any taxes, including any penalties, duties and interest, imposed by any governmental authority.
+
+**Risks.** Use of the Network may carry financial risk. Digital Assets are a novel and relatively experimental technology. Their value, if any, can fluctuate with great volatility, and transactions conducted with Digital Assets are irreversible. The use of Digital Assets in decentralized finance is inherently risky, and you acknowledge and agree that you are accessing and using the Network at your own risk. The risk of loss due to market volatility and malfeasance by other users of the Network can be substantial. Digital Assets and smart contracts are typically described using extremely technical language that is difficult to understand and requires a deep knowledge of cryptography and computer science. Dapps made available on the Network may have inherent design flaws that have not been detected in testing or may not perform as expected in conjunction with third-party technology or high-volume use. You should carefully consider whether you have sufficient understanding of the technology before accessing or using the Network.
+
+By accessing or using the Network, you hereby represent that you have the requisite knowledge and experience to evaluate the risk of the technology you are using and any transactions you undertake, and you accept the risk that the Network might not function as anticipated and that you might lose access to your Digital Assets temporarily or permanently. The Network encourages the creation of third-party Dapps and smart contract technology, but the availability of third-party Dapps and smart contract technology on the Network is not an endorsement by us of that technology. You acknowledge and agree that the Company is not a party to the smart contracts offered on the Network and that the contract counterparty to any smart contracts you enter will likely be unknown to you.
+
+You acknowledge that the Network runs on top of the decentralized Ethereum blockchain and that we have no control over the availability of the Ethereum blockchain or the price of the Digital Asset, ETH. The Ethereum protocol is open source, and anyone can use, copy or make modifications to the protocol known as "**Forks**"which could materially affect the operation of the Ethereum blockchain and thus, the Network. In the event of a Fork, you acknowledge and agree that we may temporarily or permanently suspend our operations and that we bear no liability for losses resulting from a Fork in the Ethereum blockchain.
+
+More specifically, if you are a user of any one of several smart contracts on the Network, you may be required to post collateral or pay a fee. You acknowledge that under certain circumstances, market fluctuation could require you to increase the amount of collateral required to fulfill your performance obligations under the smart contract or your collateral could diminish in value or be lost altogether. Under no circumstances will the operation of all or any portion of the Network be deemed to create a relationship that includes the provision or tendering of investment advice.
+
+The Network may become the target of sophisticated hacking attempts, cyber attacks, dramatic fluctuations in use or other technical or operational challenges that could affect its availability or ability to function properly. You accept the risk of any delays or transaction failures resulting from such interference with the Network or any third-party services connected to or operating in conjunction with the Network including other operators of decentralized networks, platforms or Dapps. You further acknowledge that decentralized lending and borrowing protocols that ultimately allow the use of Digital Assets created on our platform have no legal obligation to provide software development to or maintain their protocols, and you should not expect that their services will continue or be available at any particular time. We are not responsible for the availability of or maintenance to lending or borrowing protocols that allow interaction, through smart contracts or otherwise, with the Keep Network or Keep Digital Assets.
+
+You acknowledge that Company is a non-custodial provider of Network services. We do not provide custody services, control or manage your Digital Assets in any manner whatsoever. The Network exists in a decentralized environment through which functionality can be autonomously directly accessed by you without any involvement or actions by Company or any third-party. Use of the Network requires the use of ERC 20 compatible Wallet(s). It is your responsibility to maintain access to and the security of your Wallet. If you fail to secure your Wallet properly, you could lose access to the contents of your Wallet and you will no longer be able to access or use some Network features.
+
+In many jurisdictions, the regulatory frameworks imposed by governmental authorities over the use and sale of cryptocurrencies or Digital Assets are uncertain. Changes in regulations and policies may affect your use of the Network in your jurisdiction, and you are responsible for consulting with legal counsel and complying with all applicable laws in your jurisdiction.
+
+The Network may rely on the use of third-party platforms, exchanges, Dapps, oracles or other mechanisms to facilitate your use of the Network. We do not control the availability of those platforms, and your access to and use of the Network could be affected by changes in those platforms which are beyond our control.
+
+## Intellectual Property Rights
+
+You must not delete or alter any copyright, trademark or other proprietary rights notices from copies of materials from this site. The smart contracts and software provided by us to the Network are made available to you under the [MIT open source license](https://github.com/keep-network/keep-ecdsa/blob/master/LICENSE), and the documentation and source code are available at [https://github.com/keep-network](https://github.com/keep-network). Other third-party technology provided to the Network is owned by the third-party provider of such technology or is made available subject to the license identified with the technology.
+
+The Keep name, Company logo and other related trademarks or service marks are the exclusive property of the Company and may not be used without our prior written consent. If you breach these Terms of Use, your right to use the Network will cease immediately and you must, at our option, return or destroy any copies of the materials you have made. No right, title or interest in or to the Network or any content on the Network is transferred to you, and all rights not expressly granted are reserved by the Company. Any use of the Network not expressly permitted by these Terms of Use is a breach of these Terms of Use and may violate copyright, trademark and other laws.
+
+## Prohibited Uses
+
+You may use the Network only for lawful purposes and in accordance with these Terms of Use. You agree not to use the Network:
+
+- In any way that violates any applicable federal, state, local or international law or regulation (including, without limitation, any laws regarding the export of data or software to and from the US or other countries).
+- For the purpose of exploiting, harming or attempting to exploit or harm minors in any way by exposing them to inappropriate content, asking for personally identifiable information or otherwise.
+- To attempt to circumvent any Network security or access controls or to interfere with the operation of the Network.
+- To impersonate or attempt to impersonate the Company, a Company employee, another user or any other person or entity (including, without limitation, by using e-mail addresses or wallet addresses associated with any of the foregoing).
+- To transmit or exchange Digital Assets that are the direct or indirect proceeds of any illegal, criminal or fraudulent behavior including terrorism.
+- In any manner that could disable, overburden, damage, or impair the site or interfere with any other party's use of the Network, including their ability to engage in real time activities through the Network.
+- Use any robot, spider or other automatic device, process or means to access the Network for any purpose, including monitoring or copying any of the material on the Network.
+- Use any manual process to monitor or copy any of the material on the Network or for any other unauthorized purpose without our prior written consent.
+- Use any device, software or routine that interferes with the proper working of the Network.
+- Introduce any viruses, trojan horses, worms, logic bombs or other material which is malicious or technologically harmful.
+- Otherwise attempt to interfere with the proper working of the Network.
+
+## User Contributions
+
+The Network may contain links to social media, message boards, chat rooms, personal web pages or profiles, forums, bulletin boards, FAQs and other interactive features (collectively, "**Interactive Services**") that allow users to post, submit, publish, display, advise or transmit to other users or other persons (hereinafter, "**post**") content or materials (collectively, "**User Contributions**") on or through the Network.
+
+All User Contributions must comply with the Content Standards set out in these Terms of Use. Any User Contribution you post to the site will be considered non-confidential and non-proprietary. By providing any User Contribution on the Network, you grant us and our affiliates and service providers, and each of their and our respective licensees, successors and assigns the right to use, reproduce, modify, perform, display, distribute and otherwise disclose to third parties any such material for any purpose.
+
+You represent and warrant that:
+
+- You own or control all rights in and to the User Contributions and have the right to grant the license granted above to us and our affiliates and service providers, and each of their and our respective licensees, successors and assigns.
+- All of your User Contributions do and will comply with these Terms of Use.
+
+You understand and acknowledge that you are responsible for any User Contributions you submit or contribute, and you, not the Company, have fully responsibility for such content, including its legality, reliability, accuracy and appropriateness. We are not responsible, or liable to any third party, for the content or accuracy of any User Contributions posted by you or any other user of the Network.
+
+## Monitoring and Enforcement; Termination
+
+We have the right to:
+
+- Remove or refuse to post any User Contributions for any or no reason in our sole discretion.
+- Take any action with respect to any User Contribution that we deem necessary or appropriate in our sole discretion, including if we believe that such User Contribution violates the Terms of Use, including the Content Standards, infringes any intellectual property right or other right of any person or entity, threatens the personal safety of users of the Network or the public or could create liability for the Company.
+- Disclose information about you to any third party who claims that material posted by you violates their rights, including their intellectual property rights or their right to privacy.
+- Take appropriate legal action, including without limitation, referral to law enforcement, for any illegal or unauthorized use of the Network.
+- Terminate or suspend your access to all or part of the Network for any or no reason, including without limitation, any violation of these Terms of Use.
+
+Without limiting the foregoing, we have the right to fully cooperate with any law enforcement authorities or court order requesting or directing us to disclose the identity or other information of anyone using or posting any materials on or through the Network.
+
+However, we do not undertake to review material before it is posted on or through the Network and cannot ensure prompt removal of objectionable material after it has been posted. Accordingly, we assume no liability for any action or inaction regarding transmissions, communications or content provided by any user or third party. We have no liability or responsibility to anyone for performance or nonperformance of the activities described in this section.
+
+## Content Standards
+
+These content standards apply to any and all User Contributions and use of Interactive Services. User Contributions must in their entirety comply with all applicable federal, state, local and international laws and regulations. Without limiting the foregoing, User Contributions must not:
+
+- Contain any material which is defamatory, obscene, indecent, abusive, offensive, harassing, violent, hateful, inflammatory or otherwise objectionable.
+- Promote sexually explicit or pornographic material, violence, or discrimination based on race, sex, religion, nationality, disability, sexual orientation or age.
+- Infringe any patent, trademark, trade secret, copyright or other intellectual property or other rights of any other person.
+- Violate the legal rights (including the rights of publicity and privacy) of others or contain any material that could give rise to any civil or criminal liability under applicable laws or regulations or that otherwise may be in conflict with these Terms of Use and our [Privacy Policy](https://tbtc.network/privacy-policy).
+- Be likely to deceive any person.
+- Promote any illegal activity, or advocate, promote or assist any unlawful act.
+- Cause annoyance, inconvenience or needless anxiety or be likely to upset, embarrass, alarm or annoy any other person.
+- Impersonate any person or misrepresent your identity or affiliation with any person or organization.
+- Involve commercial activities or sales, such as contests, sweepstakes and other sales promotions, barter or advertising.
+- Give the impression that they emanate from or are endorsed by us or any other person or entity, if this is not the case.
+
+## Reliance on Information Posted
+
+The information presented on or through the Network is made available solely for general information purposes. We do not warrant the accuracy, completeness or usefulness of this information. Any reliance you place on such information is strictly at your own risk. We disclaim all liability and responsibility arising from any reliance placed on such materials by you or any other user of the Network, or by anyone who may be informed of any of its contents.
+
+This Network may include or link to content provided by third parties, including materials provided by other users, smart contract creators, third-party licensors, syndicators, aggregators, reporting services, FAQ providers and/or "how to"manuals. All statements and/or opinions expressed in such materials, and all articles and responses to questions and other content, other than the content provided by the Company, are solely the opinions and the responsibility of the person or entity providing those materials. These materials do not necessarily reflect the opinion of the Company. We are not responsible, or liable to you or any third party, for the content or accuracy of any materials provided by any third parties.
+
+## Changes to the Network
+
+We may update the content on this Network from time to time, but its content is not necessarily complete or up-to-date. We reserve the right to withdraw or amend this Network, and any service or functionality, including smart contract functionality, on the Network in our sole discretion without notice. Any of the material on the Network may be out of date at any given time, and we are under no obligation to update such material. You acknowledge that the software protocols comprising the Network are open source, and over time, by consensus of Network users or by actions of third parties beyond our controls, may be modified, copied or reproduced in different form. As such we are not responsible for the operation of the underlying protocols and make no guarantee of their functionality, security or availability. In the event of a change in the operation of the Network, you agree we may temporarily or permanently suspend our operations without liability to you.
+
+## Information About You and Your Visits to the Network
+
+All information we collect on this Network is subject to our Privacy Policy. By using the Network, you consent to all actions taken by us with respect to your information in compliance with the Privacy Policy.
+
+## Third-Party Terms and Conditions
+
+Additional terms and conditions may apply to specific portions, services or features of the Network provided by third parties including Dapps and smart contracts, either alone or in conjunction with the functionality provided by us. The use of such services or features shall be governed by the terms of use associated with them, and all such additional terms of use are hereby incorporated by this reference into these Terms of Use. We accept no liability or responsibility for any third-party functionality or any of our open source functionality that has been modified by third parties.
+
+## Links from the Network
+
+If the Network contains links to other sites and resources provided by third parties, these links are provided for your convenience only. We have no control over the contents of those sites or resources and accept no responsibility for them or for any loss or damage that may arise from your use of them. If you decide to access any of the third party sites linked to this Network, you do so entirely at your own risk and subject to the terms and conditions of use for such Networks.
+
+## Geographic Restrictions
+
+Access to the Network may not be legal by certain persons or in certain countries. You are responsible for compliance with all applicable laws in your jurisdiction.
+
+## Disclaimer of Warranties
+
+WE WILL NOT BE LIABLE FOR ANY LOSS OR DAMAGE CAUSED BY A DISTRIBUTED DENIAL-OF-SERVICE ATTACK, HACKS, VIRUSES OR OTHER TECHNOLOGICALLY HARMFUL MATERIAL THAT MAY INFECT YOUR COMPUTER EQUIPMENT, COMPUTER PROGRAMS, DATA OR OTHER PROPRIETARY MATERIAL DUE TO YOUR USE OF THE NETWORK OR ANY SERVICES OR ITEMS OBTAINED THROUGH THE NETWORK, ANY THIRD PARTY LINKS (INCLUDING BUT NOT LIMITED TO SMART CONTRACTS FAQS OR OTHER MATERIALS) ACCESSED THROUGH OR IN CONJUNCTION WITH THE NETWORK, OR ON ANY NETWORK LINKED TO IT.
+
+YOUR USE OF THE NETWORK, ITS CONTENT AND ANY SERVICES OR ITEMS OBTAINED THROUGH THE NETWORK IS AT YOUR OWN RISK. THE NETWORK, ITS CONTENT AND ANY SERVICES OR ITEMS OBTAINED THROUGH THE NETWORK ARE PROVIDED ON AN "AS IS"AND "AS AVAILABLE"BASIS, WITHOUT ANY WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED. NEITHER THE COMPANY NOR ANY PERSON ASSOCIATED WITH THE COMPANY MAKES ANY WARRANTY OR REPRESENTATION WITH RESPECT TO THE COMPLETENESS, SECURITY, RELIABILITY, QUALITY, ACCURACY OR AVAILABILITY OF THE NETWORK. WITHOUT LIMITING THE FOREGOING, NEITHER THE COMPANY NOR ANYONE ASSOCIATED WITH THE COMPANY REPRESENTS OR WARRANTS THAT THE NETWORK, ITS CONTENT OR ANY SERVICES OR ITEMS OBTAINED THROUGH THE NETWORK WILL BE ACCURATE, RELIABLE, ERROR-FREE OR UNINTERRUPTED, THAT DEFECTS WILL BE CORRECTED, THAT OUR SITE OR THE SERVER THAT MAKES IT AVAILABLE ARE FREE OF VIRUSES OR OTHER HARMFUL COMPONENTS OR THAT THE NETWORK OR ANY SERVICES OR ITEMS OBTAINED THROUGH THE NETWORK WILL OTHERWISE MEET YOUR NEEDS OR EXPECTATIONS.
+
+YOU HEREBY IRREVOCABLY WAIVE, RELEASE AND DISCHARGE ALL CLAIMS, WHETHER KNOWN OR UNKNOWN TO YOU, AGAINST US, OUR AFFILIATES AND THEIR RESPECTIVE SHAREHOLDERS, MEMBERS, DIRECTORS, OFFICERS, EMPLOYEES, AGENTS AND REPRESENTATIVES RELATED TO YOUR USE OF ANY WALLET SOFTWARE, ASSOCIATED LOSS OF FUNDS, TRANSACTION FAILURES, OR ANY OTHER DEFECTS THAT ARISE IN THE COURSE OF YOUR USE OF YOUR WALLET. THE COMPANY HEREBY DISCLAIMS ALL WARRANTIES OF ANY KIND, WHETHER EXPRESS OR IMPLIED, STATUTORY OR OTHERWISE, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF MERCHANTABILITY, NON-INFRINGEMENT AND FITNESS FOR PARTICULAR PURPOSE.
+
+THE FOREGOING DOES NOT AFFECT ANY WARRANTIES WHICH CANNOT BE EXCLUDED OR LIMITED UNDER APPLICABLE LAW.
+
+## Limitation on Liability
+
+IN NO EVENT WILL THE COMPANY, ITS AFFILIATES OR THEIR LICENSORS, SERVICE PROVIDERS, EMPLOYEES, AGENTS, OFFICERS OR DIRECTORS BE LIABLE FOR DAMAGES OF ANY KIND, UNDER ANY LEGAL THEORY, ARISING OUT OF OR IN CONNECTION WITH YOUR USE, OR INABILITY TO USE, THE NETWORK, ANY NETWORKS LINKED TO IT, ANY SMART CONTRACTS OR DISTRIBUTED APPLICATIONS EXISTING ON OR CONNECTING TO THE NETWORK, ANY LOSS OF FUNDS OR COLLATERAL, ANY CONTENT ON THE NETWORK OR SUCH OTHER NETWORKS OR ANY SERVICES OR ITEMS OBTAINED THROUGH THE NETWORK OR SUCH OTHER NETWORKS, INCLUDING ANY DIRECT, INDIRECT, SPECIAL, INCIDENTAL, CONSEQUENTIAL OR PUNITIVE DAMAGES, INCLUDING BUT NOT LIMITED TO, PERSONAL INJURY, PAIN AND SUFFERING, EMOTIONAL DISTRESS, LOSS OF REVENUE, LOSS OF PROFITS, LOSS OF BUSINESS OR ANTICIPATED SAVINGS, LOSS OF USE, LOSS OF GOODWILL, LOSS OF DATA, AND WHETHER CAUSED BY TORT (INCLUDING NEGLIGENCE), BREACH OF CONTRACT OR OTHERWISE, EVEN IF FORESEEABLE. UNDER NO CIRCUMSTANCES WILL WE BE RESPONSIBLE FOR ANY DAMAGES, LOSS OR INJURY RESULTING FROM HACKING, TAMPERING OR OTHER UNAUTHORIZED ACCESS OR USE OF THE NETWORK OR ITS CONTENTS.
+
+THE FOREGOING DOES NOT AFFECT ANY LIABILITY WHICH CANNOT BE EXCLUDED OR LIMITED UNDER APPLICABLE LAW.
+
+## Indemnification
+
+You agree to defend, indemnify and hold harmless the Company, its affiliates, licensors and service providers, and its and their respective officers, directors, employees, contractors, agents, licensors, suppliers, successors and assigns from and against any claims, liabilities, damages, judgments, awards, losses, costs, expenses, debts and fees (including reasonable attorneys' fees) arising out of or relating to: your use of or access to the Network; your violation of any third party right; the provision by you of any false or misleading information; your violation of any law, rule or regulation; your violation of these Terms of Use; your willful misconduct; or your use of the Network, including, but not limited to, your User Contributions, any use of the Network's content, services and products other than as expressly authorized in these Terms of Use or your use of any information obtained from the Network.
+
+## Release of Claims
+
+You acknowledge that the Network (including without limitation the smart contracts) and your use of the Network contain certain risks, including without limitation the following risks:  any smart contracts you interact with are entirely your own responsibility and your own liability, and we are not a party to the smart contracts; At any time, your access to your Digital Assets may be suspended or terminated or there may be a delay in your access or use of your Digital Assets which may result in the Digital Assets diminishing in value or you being unable to complete a smart contract; if your collateral declines such that your collateral is no longer sufficient to secure your position as a signer or depositor that a liquidation auction may not produce sufficient revenue to return your collateral, or other users may seize your collateral to close out your account; and the Network and related smart contracts may be suspended or terminated for any or no reason, which may limit your access to your Digital Assets. You assume all risk in connection with your access to and use of the Network and its smart contracts, and you waive and release us from any and all liability, claims, causes of action or damages arising from or in any way related to your use of the Network or the smart contracts.
+
+## Governing Law and Jurisdiction
+
+All matters relating to the Network and these Terms of Use and any dispute or claim arising therefrom or related thereto (in each case, including non-contractual disputes or claims), shall be governed by and construed in accordance with the internal laws of the Cayman Islands without giving effect to any choice or conflict of law provision or rule.
+
+Any legal suit, action or proceeding arising out of, or related to, these Terms of Use or the Network shall be instituted exclusively in the courts of the Cayman Islands. You waive any and all objections to the exercise of jurisdiction over you by such courts and to venue in such courts.
+
+## Arbitration
+
+At Company's sole discretion, it may require You to submit any disputes arising from the use of these Terms of Use or the Network, including disputes arising from or concerning their interpretation, violation, invalidity, non-performance, or termination, to final and binding arbitration under the Rules of Arbitration of the American Arbitration Association applying Cayman Island law.
+
+## Limitation on Time to File Claims
+
+ANY CAUSE OF ACTION OR CLAIM YOU MAY HAVE ARISING OUT OF OR RELATING TO THESE TERMS OF USE OR THE NETWORK MUST BE COMMENCED WITHIN ONE (1) YEAR AFTER THE CAUSE OF ACTION ACCRUES, OTHERWISE, SUCH CAUSE OF ACTION OR CLAIM IS PERMANENTLY BARRED.
+
+## Waiver and Severability
+
+No waiver of by the Company of any term or condition set forth in these Terms of Use shall be deemed a further or continuing waiver of such term or condition or a waiver of any other term or condition, and any failure of the Company to assert a right or provision under these Terms of Use shall not constitute a waiver of such right or provision.
+
+If any provision of these Terms of Use is held by a court or other tribunal of competent jurisdiction to be invalid, illegal or unenforceable for any reason, such provision shall be eliminated or limited to the minimum extent such that the remaining provisions of the Terms of Use will continue in full force and effect.
+
+## Entire Agreement
+
+The Terms of Use and our Privacy Policy constitute the sole and entire agreement between you and Keep SECZ with respect to the Network and supersede all prior and contemporaneous understandings, agreements, representations and warranties, both written and oral, with respect to the Network.
+
+## Your Comments and Concerns
+
+This Network is initially operated by Keep SEZC.
+
+All feedback, comments, requests for technical support and other communications relating to the Network should be directed to: [legal@keep.network](mailto:legal@keep.network).
+
+0142785.0724991 4828-0651-3078v3

--- a/src/pages/terms-of-use/index.fr.md
+++ b/src/pages/terms-of-use/index.fr.md
@@ -1,0 +1,204 @@
+---
+template: legal-page
+path: /terms-of-use
+title: tBTC Network Terms of Use
+---
+Last Modified: May 1, 2020
+
+## Acceptance of the Terms of Use
+
+These terms of use are entered into by and between You and Keep SECZ, a Cayman Islands special economic zone company ("**Company**", "**we**" or "**us**"). The following terms and conditions, together with any documents they expressly incorporate by reference (collectively, these "**Terms of Use**"), govern your access to and use of the network located at [tbtc.network](https://tbtc.network/) as well as any content, functionality, smart contracts, distributed applications ("Dapps") and services offered on or through the tBTC network (collectively, the "**Network**"). The Network is currently administered by the Company using open source protocols; however, we intend over time for the Network and the network protocol to become decentralized and governed entirely by the community of its users in whatever manner they determine.
+
+Please read the Terms of Use carefully before you start to use the Network. **By using the Network or by clicking to accept or agree to the Terms of Use when this option is made available to you, you accept and agree to be bound and abide by these Terms of Use and our [Privacy Policy](/privacy-policy), incorporated herein by reference.** If you do not want to agree to these Terms of Use or the [Privacy Policy](/privacy-policy), you must not access or use the Network.
+
+This Network is offered and available to users who are 18 years of age or older who are not residents of countries named on the [US Department of the Treasury Sanctions list](https://www.treasury.gov/resource-center/sanctions/Programs/Pages/Programs.aspx) or named on the Office of Foreign Asset Control's list of [Specially Designated Nationals and Blocked Persons](https://www.treasury.gov/resource-center/sanctions/SDN-List/Pages/default.aspx) ("SDN List"). If the user is an organization, you affirm you have the right, power and authority to enter into this agreement on behalf of the organization and bind the organization to its terms. If you do not agree to the terms of this agreement, you must not use the Network or any of our services. By using this Network, you represent and warrant that you are of legal age to form a binding contract with the Company and meet all of the foregoing eligibility requirements. You represent that you are legally permitted to use the Network in your jurisdiction including owning Digital Assets and interacting with the Network in any way.If you do not meet all of these requirements, you must not access or use the Network. Without limiting the foregoing, by using the Network, you acknowledge and understand that laws regarding financial instruments, which sometimes include cryptographic tokens, also known as "**Digital Assets**", and decentralized finance may vary from jurisdiction to jurisdiction, and it is your obligation alone to ensure that you fully comply with any law, regulation or directive, relevant to your jurisdiction with regard to the use of the Network. You further represent and warrant that you will not use the Network or access its smart contract functionality if the laws of your country of residency or establishment prohibit you from doing so in accordance with this agreement. For the avoidance of doubt, the ability to access the Network does not necessarily mean that the Network, or your activities through it, are legal under the laws, regulations or directives relevant to your jurisdiction. All of the Network or the services made available through the Network may not be available to all users, and we reserve the right to assess or reassess at any time your eligibility to use all or part of our Network. The availability of the Network does not constitute, and may not be used for the purposes of, an offer or solicitation to anyone in any jurisdiction in which such offer or solicitation is not authorized, or to any person to whom it is unlawful to make such an offer or solicitation. By accessing or using the Network, you explicitly agree that the smart contracts built into the Dapps that comprise the Network are legally binding and enforceable upon you and the contract counterparty.
+
+## Changes to the Terms of Use
+
+We, or in the future, a decentralized governing body, may revise and update these Terms of Use from time to time in our sole discretion. All changes are effective immediately when we post them and apply to all access to and use of the Network thereafter. However, any changes to the dispute resolution provisions set forth in Governing Law and Jurisdiction will not apply to any disputes for which the parties have actual notice on or prior to the date the change is posted on the Network.
+
+Your continued use of the Network following the posting of revised Terms of Use means that you accept and agree to the changes. You are expected to check this page each time you access this Network so you are aware of any changes, as they are binding on you.
+
+## Accessing the Network and Account Security
+
+To access the Network or some of the resources it offers, you may be asked to provide an Ethereum wallet address (a "**Wallet**"). It is your sole responsibility to maintain the security of your Wallet. If you lose access to your Wallet, a private key, password, or other method of securing your Wallet, any funds may be irretrievable, and we will be unable to assist you in any way. You hereby irrevocably waive, release and discharge all claims, whether known or unknown to you, against us, our affiliates and their respective shareholders, members, directors, officers, employees, agents and representatives related to your use of any Wallet software, associated loss of funds, transaction failures, or any other defects that arise in the course of your use of your Wallet, including any losses that may obtain as a result of any failure in smart contracts made available on the Network. By using the Network, you agree to be fully, independently and personally liable for each transaction made on the Network by you, and you must make sure that you are the only person with access to your Wallet at all times. You hereby accept responsibility for any activity transacted on the Network through your Wallet.
+
+We will use commercially reasonable technical and physical safeguards to make the Network securely available to its users. However, given the inherent risk of transmitting information over the internet and the relatively new and untested nature of decentralized finance, we will not be liable if for any reason all or any part of the Network is unavailable at any time or for any period. You alone are responsible for evaluating any code provided by or used on the Network. From time to time, we may restrict access to some parts of the Network, or the entire Network, to users. You are responsible for making all arrangements necessary for you to have access to the Network and ensuring that all persons who access the Network through your internet connection are aware of these Terms of Use and comply with them.
+
+It is a condition of your use of the Network that all the information you provide on the Network is correct, current and complete. You agree that all information you provide to this Network or otherwise, including but not limited to through the use of any interactive features on the Network, is governed by our [_Privacy Policy_](https://tbtc.network/privacy-policy), and you consent to all actions we take with respect to your information consistent with our Privacy Policy.
+
+## Fees
+
+Some services on the Network involve the use of blockchains, including the Ethereum blockchain, which may require that you pay a fee, such as "**Ethereum Gas Charges**", for the computational resources required to perform a transaction. You acknowledge and agree that the Company has no control over these fees, including: 
+
+- (a) any Ethereum blockchain transactions;
+- (b) the method of payment of any Ethereum Gas Charges; or 
+- (c) any actual payments of Ethereum Gas Charges.
+
+Accordingly, you must ensure that you have a sufficient balance of digital assets, such as Ether, stored at your Wallet to complete any transaction on the Ethereum blockchain network before initiating such transactions. You may be subject to additional fees and charges, including fees required to access certain smart contracts. You acknowledge that such fees may be adjusted from time to time by us or by other users who set the terms of their own smart contracts. If you do not agree with the fees charged for Network functionality, do not use or access the Network.
+
+The use of certain smart contract functionality on the Network may require the purchase of Keep Digital Assets, the payment of fees or the posting of collateral in other types of Digital Assets as determined by the creator of such smart contract. You agree that any such fees or requirements are reasonable, and your use of the Network or any related smart contracts shall constitute your acceptance of such fees or requirements.
+
+Notwithstanding anything in this Agreement to the contrary, it is your sole responsibility to determine whether, and to what extent, any taxes apply to any transactions you conduct through the Network, and to withhold, collect, report and remit the correct amount of taxes to the appropriate tax authorities. You agree to indemnify and hold us harmless for your failure to pay any taxes, including any penalties, duties and interest, imposed by any governmental authority.
+
+**Risks.** Use of the Network may carry financial risk. Digital Assets are a novel and relatively experimental technology. Their value, if any, can fluctuate with great volatility, and transactions conducted with Digital Assets are irreversible. The use of Digital Assets in decentralized finance is inherently risky, and you acknowledge and agree that you are accessing and using the Network at your own risk. The risk of loss due to market volatility and malfeasance by other users of the Network can be substantial. Digital Assets and smart contracts are typically described using extremely technical language that is difficult to understand and requires a deep knowledge of cryptography and computer science. Dapps made available on the Network may have inherent design flaws that have not been detected in testing or may not perform as expected in conjunction with third-party technology or high-volume use. You should carefully consider whether you have sufficient understanding of the technology before accessing or using the Network.
+
+By accessing or using the Network, you hereby represent that you have the requisite knowledge and experience to evaluate the risk of the technology you are using and any transactions you undertake, and you accept the risk that the Network might not function as anticipated and that you might lose access to your Digital Assets temporarily or permanently. The Network encourages the creation of third-party Dapps and smart contract technology, but the availability of third-party Dapps and smart contract technology on the Network is not an endorsement by us of that technology. You acknowledge and agree that the Company is not a party to the smart contracts offered on the Network and that the contract counterparty to any smart contracts you enter will likely be unknown to you.
+
+You acknowledge that the Network runs on top of the decentralized Ethereum blockchain and that we have no control over the availability of the Ethereum blockchain or the price of the Digital Asset, ETH. The Ethereum protocol is open source, and anyone can use, copy or make modifications to the protocol known as "**Forks**"which could materially affect the operation of the Ethereum blockchain and thus, the Network. In the event of a Fork, you acknowledge and agree that we may temporarily or permanently suspend our operations and that we bear no liability for losses resulting from a Fork in the Ethereum blockchain.
+
+More specifically, if you are a user of any one of several smart contracts on the Network, you may be required to post collateral or pay a fee. You acknowledge that under certain circumstances, market fluctuation could require you to increase the amount of collateral required to fulfill your performance obligations under the smart contract or your collateral could diminish in value or be lost altogether. Under no circumstances will the operation of all or any portion of the Network be deemed to create a relationship that includes the provision or tendering of investment advice.
+
+The Network may become the target of sophisticated hacking attempts, cyber attacks, dramatic fluctuations in use or other technical or operational challenges that could affect its availability or ability to function properly. You accept the risk of any delays or transaction failures resulting from such interference with the Network or any third-party services connected to or operating in conjunction with the Network including other operators of decentralized networks, platforms or Dapps. You further acknowledge that decentralized lending and borrowing protocols that ultimately allow the use of Digital Assets created on our platform have no legal obligation to provide software development to or maintain their protocols, and you should not expect that their services will continue or be available at any particular time. We are not responsible for the availability of or maintenance to lending or borrowing protocols that allow interaction, through smart contracts or otherwise, with the Keep Network or Keep Digital Assets.
+
+You acknowledge that Company is a non-custodial provider of Network services. We do not provide custody services, control or manage your Digital Assets in any manner whatsoever. The Network exists in a decentralized environment through which functionality can be autonomously directly accessed by you without any involvement or actions by Company or any third-party. Use of the Network requires the use of ERC 20 compatible Wallet(s). It is your responsibility to maintain access to and the security of your Wallet. If you fail to secure your Wallet properly, you could lose access to the contents of your Wallet and you will no longer be able to access or use some Network features.
+
+In many jurisdictions, the regulatory frameworks imposed by governmental authorities over the use and sale of cryptocurrencies or Digital Assets are uncertain. Changes in regulations and policies may affect your use of the Network in your jurisdiction, and you are responsible for consulting with legal counsel and complying with all applicable laws in your jurisdiction.
+
+The Network may rely on the use of third-party platforms, exchanges, Dapps, oracles or other mechanisms to facilitate your use of the Network. We do not control the availability of those platforms, and your access to and use of the Network could be affected by changes in those platforms which are beyond our control.
+
+## Intellectual Property Rights
+
+You must not delete or alter any copyright, trademark or other proprietary rights notices from copies of materials from this site. The smart contracts and software provided by us to the Network are made available to you under the [MIT open source license](https://github.com/keep-network/keep-ecdsa/blob/master/LICENSE), and the documentation and source code are available at [https://github.com/keep-network](https://github.com/keep-network). Other third-party technology provided to the Network is owned by the third-party provider of such technology or is made available subject to the license identified with the technology.
+
+The Keep name, Company logo and other related trademarks or service marks are the exclusive property of the Company and may not be used without our prior written consent. If you breach these Terms of Use, your right to use the Network will cease immediately and you must, at our option, return or destroy any copies of the materials you have made. No right, title or interest in or to the Network or any content on the Network is transferred to you, and all rights not expressly granted are reserved by the Company. Any use of the Network not expressly permitted by these Terms of Use is a breach of these Terms of Use and may violate copyright, trademark and other laws.
+
+## Prohibited Uses
+
+You may use the Network only for lawful purposes and in accordance with these Terms of Use. You agree not to use the Network:
+
+- In any way that violates any applicable federal, state, local or international law or regulation (including, without limitation, any laws regarding the export of data or software to and from the US or other countries).
+- For the purpose of exploiting, harming or attempting to exploit or harm minors in any way by exposing them to inappropriate content, asking for personally identifiable information or otherwise.
+- To attempt to circumvent any Network security or access controls or to interfere with the operation of the Network.
+- To impersonate or attempt to impersonate the Company, a Company employee, another user or any other person or entity (including, without limitation, by using e-mail addresses or wallet addresses associated with any of the foregoing).
+- To transmit or exchange Digital Assets that are the direct or indirect proceeds of any illegal, criminal or fraudulent behavior including terrorism.
+- In any manner that could disable, overburden, damage, or impair the site or interfere with any other party's use of the Network, including their ability to engage in real time activities through the Network.
+- Use any robot, spider or other automatic device, process or means to access the Network for any purpose, including monitoring or copying any of the material on the Network.
+- Use any manual process to monitor or copy any of the material on the Network or for any other unauthorized purpose without our prior written consent.
+- Use any device, software or routine that interferes with the proper working of the Network.
+- Introduce any viruses, trojan horses, worms, logic bombs or other material which is malicious or technologically harmful.
+- Otherwise attempt to interfere with the proper working of the Network.
+
+## User Contributions
+
+The Network may contain links to social media, message boards, chat rooms, personal web pages or profiles, forums, bulletin boards, FAQs and other interactive features (collectively, "**Interactive Services**") that allow users to post, submit, publish, display, advise or transmit to other users or other persons (hereinafter, "**post**") content or materials (collectively, "**User Contributions**") on or through the Network.
+
+All User Contributions must comply with the Content Standards set out in these Terms of Use. Any User Contribution you post to the site will be considered non-confidential and non-proprietary. By providing any User Contribution on the Network, you grant us and our affiliates and service providers, and each of their and our respective licensees, successors and assigns the right to use, reproduce, modify, perform, display, distribute and otherwise disclose to third parties any such material for any purpose.
+
+You represent and warrant that:
+
+- You own or control all rights in and to the User Contributions and have the right to grant the license granted above to us and our affiliates and service providers, and each of their and our respective licensees, successors and assigns.
+- All of your User Contributions do and will comply with these Terms of Use.
+
+You understand and acknowledge that you are responsible for any User Contributions you submit or contribute, and you, not the Company, have fully responsibility for such content, including its legality, reliability, accuracy and appropriateness. We are not responsible, or liable to any third party, for the content or accuracy of any User Contributions posted by you or any other user of the Network.
+
+## Monitoring and Enforcement; Termination
+
+We have the right to:
+
+- Remove or refuse to post any User Contributions for any or no reason in our sole discretion.
+- Take any action with respect to any User Contribution that we deem necessary or appropriate in our sole discretion, including if we believe that such User Contribution violates the Terms of Use, including the Content Standards, infringes any intellectual property right or other right of any person or entity, threatens the personal safety of users of the Network or the public or could create liability for the Company.
+- Disclose information about you to any third party who claims that material posted by you violates their rights, including their intellectual property rights or their right to privacy.
+- Take appropriate legal action, including without limitation, referral to law enforcement, for any illegal or unauthorized use of the Network.
+- Terminate or suspend your access to all or part of the Network for any or no reason, including without limitation, any violation of these Terms of Use.
+
+Without limiting the foregoing, we have the right to fully cooperate with any law enforcement authorities or court order requesting or directing us to disclose the identity or other information of anyone using or posting any materials on or through the Network.
+
+However, we do not undertake to review material before it is posted on or through the Network and cannot ensure prompt removal of objectionable material after it has been posted. Accordingly, we assume no liability for any action or inaction regarding transmissions, communications or content provided by any user or third party. We have no liability or responsibility to anyone for performance or nonperformance of the activities described in this section.
+
+## Content Standards
+
+These content standards apply to any and all User Contributions and use of Interactive Services. User Contributions must in their entirety comply with all applicable federal, state, local and international laws and regulations. Without limiting the foregoing, User Contributions must not:
+
+- Contain any material which is defamatory, obscene, indecent, abusive, offensive, harassing, violent, hateful, inflammatory or otherwise objectionable.
+- Promote sexually explicit or pornographic material, violence, or discrimination based on race, sex, religion, nationality, disability, sexual orientation or age.
+- Infringe any patent, trademark, trade secret, copyright or other intellectual property or other rights of any other person.
+- Violate the legal rights (including the rights of publicity and privacy) of others or contain any material that could give rise to any civil or criminal liability under applicable laws or regulations or that otherwise may be in conflict with these Terms of Use and our [Privacy Policy](https://tbtc.network/privacy-policy).
+- Be likely to deceive any person.
+- Promote any illegal activity, or advocate, promote or assist any unlawful act.
+- Cause annoyance, inconvenience or needless anxiety or be likely to upset, embarrass, alarm or annoy any other person.
+- Impersonate any person or misrepresent your identity or affiliation with any person or organization.
+- Involve commercial activities or sales, such as contests, sweepstakes and other sales promotions, barter or advertising.
+- Give the impression that they emanate from or are endorsed by us or any other person or entity, if this is not the case.
+
+## Reliance on Information Posted
+
+The information presented on or through the Network is made available solely for general information purposes. We do not warrant the accuracy, completeness or usefulness of this information. Any reliance you place on such information is strictly at your own risk. We disclaim all liability and responsibility arising from any reliance placed on such materials by you or any other user of the Network, or by anyone who may be informed of any of its contents.
+
+This Network may include or link to content provided by third parties, including materials provided by other users, smart contract creators, third-party licensors, syndicators, aggregators, reporting services, FAQ providers and/or "how to"manuals. All statements and/or opinions expressed in such materials, and all articles and responses to questions and other content, other than the content provided by the Company, are solely the opinions and the responsibility of the person or entity providing those materials. These materials do not necessarily reflect the opinion of the Company. We are not responsible, or liable to you or any third party, for the content or accuracy of any materials provided by any third parties.
+
+## Changes to the Network
+
+We may update the content on this Network from time to time, but its content is not necessarily complete or up-to-date. We reserve the right to withdraw or amend this Network, and any service or functionality, including smart contract functionality, on the Network in our sole discretion without notice. Any of the material on the Network may be out of date at any given time, and we are under no obligation to update such material. You acknowledge that the software protocols comprising the Network are open source, and over time, by consensus of Network users or by actions of third parties beyond our controls, may be modified, copied or reproduced in different form. As such we are not responsible for the operation of the underlying protocols and make no guarantee of their functionality, security or availability. In the event of a change in the operation of the Network, you agree we may temporarily or permanently suspend our operations without liability to you.
+
+## Information About You and Your Visits to the Network
+
+All information we collect on this Network is subject to our Privacy Policy. By using the Network, you consent to all actions taken by us with respect to your information in compliance with the Privacy Policy.
+
+## Third-Party Terms and Conditions
+
+Additional terms and conditions may apply to specific portions, services or features of the Network provided by third parties including Dapps and smart contracts, either alone or in conjunction with the functionality provided by us. The use of such services or features shall be governed by the terms of use associated with them, and all such additional terms of use are hereby incorporated by this reference into these Terms of Use. We accept no liability or responsibility for any third-party functionality or any of our open source functionality that has been modified by third parties.
+
+## Links from the Network
+
+If the Network contains links to other sites and resources provided by third parties, these links are provided for your convenience only. We have no control over the contents of those sites or resources and accept no responsibility for them or for any loss or damage that may arise from your use of them. If you decide to access any of the third party sites linked to this Network, you do so entirely at your own risk and subject to the terms and conditions of use for such Networks.
+
+## Geographic Restrictions
+
+Access to the Network may not be legal by certain persons or in certain countries. You are responsible for compliance with all applicable laws in your jurisdiction.
+
+## Disclaimer of Warranties
+
+WE WILL NOT BE LIABLE FOR ANY LOSS OR DAMAGE CAUSED BY A DISTRIBUTED DENIAL-OF-SERVICE ATTACK, HACKS, VIRUSES OR OTHER TECHNOLOGICALLY HARMFUL MATERIAL THAT MAY INFECT YOUR COMPUTER EQUIPMENT, COMPUTER PROGRAMS, DATA OR OTHER PROPRIETARY MATERIAL DUE TO YOUR USE OF THE NETWORK OR ANY SERVICES OR ITEMS OBTAINED THROUGH THE NETWORK, ANY THIRD PARTY LINKS (INCLUDING BUT NOT LIMITED TO SMART CONTRACTS FAQS OR OTHER MATERIALS) ACCESSED THROUGH OR IN CONJUNCTION WITH THE NETWORK, OR ON ANY NETWORK LINKED TO IT.
+
+YOUR USE OF THE NETWORK, ITS CONTENT AND ANY SERVICES OR ITEMS OBTAINED THROUGH THE NETWORK IS AT YOUR OWN RISK. THE NETWORK, ITS CONTENT AND ANY SERVICES OR ITEMS OBTAINED THROUGH THE NETWORK ARE PROVIDED ON AN "AS IS"AND "AS AVAILABLE"BASIS, WITHOUT ANY WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED. NEITHER THE COMPANY NOR ANY PERSON ASSOCIATED WITH THE COMPANY MAKES ANY WARRANTY OR REPRESENTATION WITH RESPECT TO THE COMPLETENESS, SECURITY, RELIABILITY, QUALITY, ACCURACY OR AVAILABILITY OF THE NETWORK. WITHOUT LIMITING THE FOREGOING, NEITHER THE COMPANY NOR ANYONE ASSOCIATED WITH THE COMPANY REPRESENTS OR WARRANTS THAT THE NETWORK, ITS CONTENT OR ANY SERVICES OR ITEMS OBTAINED THROUGH THE NETWORK WILL BE ACCURATE, RELIABLE, ERROR-FREE OR UNINTERRUPTED, THAT DEFECTS WILL BE CORRECTED, THAT OUR SITE OR THE SERVER THAT MAKES IT AVAILABLE ARE FREE OF VIRUSES OR OTHER HARMFUL COMPONENTS OR THAT THE NETWORK OR ANY SERVICES OR ITEMS OBTAINED THROUGH THE NETWORK WILL OTHERWISE MEET YOUR NEEDS OR EXPECTATIONS.
+
+YOU HEREBY IRREVOCABLY WAIVE, RELEASE AND DISCHARGE ALL CLAIMS, WHETHER KNOWN OR UNKNOWN TO YOU, AGAINST US, OUR AFFILIATES AND THEIR RESPECTIVE SHAREHOLDERS, MEMBERS, DIRECTORS, OFFICERS, EMPLOYEES, AGENTS AND REPRESENTATIVES RELATED TO YOUR USE OF ANY WALLET SOFTWARE, ASSOCIATED LOSS OF FUNDS, TRANSACTION FAILURES, OR ANY OTHER DEFECTS THAT ARISE IN THE COURSE OF YOUR USE OF YOUR WALLET. THE COMPANY HEREBY DISCLAIMS ALL WARRANTIES OF ANY KIND, WHETHER EXPRESS OR IMPLIED, STATUTORY OR OTHERWISE, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF MERCHANTABILITY, NON-INFRINGEMENT AND FITNESS FOR PARTICULAR PURPOSE.
+
+THE FOREGOING DOES NOT AFFECT ANY WARRANTIES WHICH CANNOT BE EXCLUDED OR LIMITED UNDER APPLICABLE LAW.
+
+## Limitation on Liability
+
+IN NO EVENT WILL THE COMPANY, ITS AFFILIATES OR THEIR LICENSORS, SERVICE PROVIDERS, EMPLOYEES, AGENTS, OFFICERS OR DIRECTORS BE LIABLE FOR DAMAGES OF ANY KIND, UNDER ANY LEGAL THEORY, ARISING OUT OF OR IN CONNECTION WITH YOUR USE, OR INABILITY TO USE, THE NETWORK, ANY NETWORKS LINKED TO IT, ANY SMART CONTRACTS OR DISTRIBUTED APPLICATIONS EXISTING ON OR CONNECTING TO THE NETWORK, ANY LOSS OF FUNDS OR COLLATERAL, ANY CONTENT ON THE NETWORK OR SUCH OTHER NETWORKS OR ANY SERVICES OR ITEMS OBTAINED THROUGH THE NETWORK OR SUCH OTHER NETWORKS, INCLUDING ANY DIRECT, INDIRECT, SPECIAL, INCIDENTAL, CONSEQUENTIAL OR PUNITIVE DAMAGES, INCLUDING BUT NOT LIMITED TO, PERSONAL INJURY, PAIN AND SUFFERING, EMOTIONAL DISTRESS, LOSS OF REVENUE, LOSS OF PROFITS, LOSS OF BUSINESS OR ANTICIPATED SAVINGS, LOSS OF USE, LOSS OF GOODWILL, LOSS OF DATA, AND WHETHER CAUSED BY TORT (INCLUDING NEGLIGENCE), BREACH OF CONTRACT OR OTHERWISE, EVEN IF FORESEEABLE. UNDER NO CIRCUMSTANCES WILL WE BE RESPONSIBLE FOR ANY DAMAGES, LOSS OR INJURY RESULTING FROM HACKING, TAMPERING OR OTHER UNAUTHORIZED ACCESS OR USE OF THE NETWORK OR ITS CONTENTS.
+
+THE FOREGOING DOES NOT AFFECT ANY LIABILITY WHICH CANNOT BE EXCLUDED OR LIMITED UNDER APPLICABLE LAW.
+
+## Indemnification
+
+You agree to defend, indemnify and hold harmless the Company, its affiliates, licensors and service providers, and its and their respective officers, directors, employees, contractors, agents, licensors, suppliers, successors and assigns from and against any claims, liabilities, damages, judgments, awards, losses, costs, expenses, debts and fees (including reasonable attorneys' fees) arising out of or relating to: your use of or access to the Network; your violation of any third party right; the provision by you of any false or misleading information; your violation of any law, rule or regulation; your violation of these Terms of Use; your willful misconduct; or your use of the Network, including, but not limited to, your User Contributions, any use of the Network's content, services and products other than as expressly authorized in these Terms of Use or your use of any information obtained from the Network.
+
+## Release of Claims
+
+You acknowledge that the Network (including without limitation the smart contracts) and your use of the Network contain certain risks, including without limitation the following risks:  any smart contracts you interact with are entirely your own responsibility and your own liability, and we are not a party to the smart contracts; At any time, your access to your Digital Assets may be suspended or terminated or there may be a delay in your access or use of your Digital Assets which may result in the Digital Assets diminishing in value or you being unable to complete a smart contract; if your collateral declines such that your collateral is no longer sufficient to secure your position as a signer or depositor that a liquidation auction may not produce sufficient revenue to return your collateral, or other users may seize your collateral to close out your account; and the Network and related smart contracts may be suspended or terminated for any or no reason, which may limit your access to your Digital Assets. You assume all risk in connection with your access to and use of the Network and its smart contracts, and you waive and release us from any and all liability, claims, causes of action or damages arising from or in any way related to your use of the Network or the smart contracts.
+
+## Governing Law and Jurisdiction
+
+All matters relating to the Network and these Terms of Use and any dispute or claim arising therefrom or related thereto (in each case, including non-contractual disputes or claims), shall be governed by and construed in accordance with the internal laws of the Cayman Islands without giving effect to any choice or conflict of law provision or rule.
+
+Any legal suit, action or proceeding arising out of, or related to, these Terms of Use or the Network shall be instituted exclusively in the courts of the Cayman Islands. You waive any and all objections to the exercise of jurisdiction over you by such courts and to venue in such courts.
+
+## Arbitration
+
+At Company's sole discretion, it may require You to submit any disputes arising from the use of these Terms of Use or the Network, including disputes arising from or concerning their interpretation, violation, invalidity, non-performance, or termination, to final and binding arbitration under the Rules of Arbitration of the American Arbitration Association applying Cayman Island law.
+
+## Limitation on Time to File Claims
+
+ANY CAUSE OF ACTION OR CLAIM YOU MAY HAVE ARISING OUT OF OR RELATING TO THESE TERMS OF USE OR THE NETWORK MUST BE COMMENCED WITHIN ONE (1) YEAR AFTER THE CAUSE OF ACTION ACCRUES, OTHERWISE, SUCH CAUSE OF ACTION OR CLAIM IS PERMANENTLY BARRED.
+
+## Waiver and Severability
+
+No waiver of by the Company of any term or condition set forth in these Terms of Use shall be deemed a further or continuing waiver of such term or condition or a waiver of any other term or condition, and any failure of the Company to assert a right or provision under these Terms of Use shall not constitute a waiver of such right or provision.
+
+If any provision of these Terms of Use is held by a court or other tribunal of competent jurisdiction to be invalid, illegal or unenforceable for any reason, such provision shall be eliminated or limited to the minimum extent such that the remaining provisions of the Terms of Use will continue in full force and effect.
+
+## Entire Agreement
+
+The Terms of Use and our Privacy Policy constitute the sole and entire agreement between you and Keep SECZ with respect to the Network and supersede all prior and contemporaneous understandings, agreements, representations and warranties, both written and oral, with respect to the Network.
+
+## Your Comments and Concerns
+
+This Network is initially operated by Keep SEZC.
+
+All feedback, comments, requests for technical support and other communications relating to the Network should be directed to: [legal@keep.network](mailto:legal@keep.network).
+
+0142785.0724991 4828-0651-3078v3

--- a/src/pages/terms-of-use/index.pl.md
+++ b/src/pages/terms-of-use/index.pl.md
@@ -1,0 +1,204 @@
+---
+template: legal-page
+path: /terms-of-use
+title: tBTC Network Terms of Use
+---
+Last Modified: May 1, 2020
+
+## Acceptance of the Terms of Use
+
+These terms of use are entered into by and between You and Keep SECZ, a Cayman Islands special economic zone company ("**Company**", "**we**" or "**us**"). The following terms and conditions, together with any documents they expressly incorporate by reference (collectively, these "**Terms of Use**"), govern your access to and use of the network located at [tbtc.network](https://tbtc.network/) as well as any content, functionality, smart contracts, distributed applications ("Dapps") and services offered on or through the tBTC network (collectively, the "**Network**"). The Network is currently administered by the Company using open source protocols; however, we intend over time for the Network and the network protocol to become decentralized and governed entirely by the community of its users in whatever manner they determine.
+
+Please read the Terms of Use carefully before you start to use the Network. **By using the Network or by clicking to accept or agree to the Terms of Use when this option is made available to you, you accept and agree to be bound and abide by these Terms of Use and our [Privacy Policy](/privacy-policy), incorporated herein by reference.** If you do not want to agree to these Terms of Use or the [Privacy Policy](/privacy-policy), you must not access or use the Network.
+
+This Network is offered and available to users who are 18 years of age or older who are not residents of countries named on the [US Department of the Treasury Sanctions list](https://www.treasury.gov/resource-center/sanctions/Programs/Pages/Programs.aspx) or named on the Office of Foreign Asset Control's list of [Specially Designated Nationals and Blocked Persons](https://www.treasury.gov/resource-center/sanctions/SDN-List/Pages/default.aspx) ("SDN List"). If the user is an organization, you affirm you have the right, power and authority to enter into this agreement on behalf of the organization and bind the organization to its terms. If you do not agree to the terms of this agreement, you must not use the Network or any of our services. By using this Network, you represent and warrant that you are of legal age to form a binding contract with the Company and meet all of the foregoing eligibility requirements. You represent that you are legally permitted to use the Network in your jurisdiction including owning Digital Assets and interacting with the Network in any way.If you do not meet all of these requirements, you must not access or use the Network. Without limiting the foregoing, by using the Network, you acknowledge and understand that laws regarding financial instruments, which sometimes include cryptographic tokens, also known as "**Digital Assets**", and decentralized finance may vary from jurisdiction to jurisdiction, and it is your obligation alone to ensure that you fully comply with any law, regulation or directive, relevant to your jurisdiction with regard to the use of the Network. You further represent and warrant that you will not use the Network or access its smart contract functionality if the laws of your country of residency or establishment prohibit you from doing so in accordance with this agreement. For the avoidance of doubt, the ability to access the Network does not necessarily mean that the Network, or your activities through it, are legal under the laws, regulations or directives relevant to your jurisdiction. All of the Network or the services made available through the Network may not be available to all users, and we reserve the right to assess or reassess at any time your eligibility to use all or part of our Network. The availability of the Network does not constitute, and may not be used for the purposes of, an offer or solicitation to anyone in any jurisdiction in which such offer or solicitation is not authorized, or to any person to whom it is unlawful to make such an offer or solicitation. By accessing or using the Network, you explicitly agree that the smart contracts built into the Dapps that comprise the Network are legally binding and enforceable upon you and the contract counterparty.
+
+## Changes to the Terms of Use
+
+We, or in the future, a decentralized governing body, may revise and update these Terms of Use from time to time in our sole discretion. All changes are effective immediately when we post them and apply to all access to and use of the Network thereafter. However, any changes to the dispute resolution provisions set forth in Governing Law and Jurisdiction will not apply to any disputes for which the parties have actual notice on or prior to the date the change is posted on the Network.
+
+Your continued use of the Network following the posting of revised Terms of Use means that you accept and agree to the changes. You are expected to check this page each time you access this Network so you are aware of any changes, as they are binding on you.
+
+## Accessing the Network and Account Security
+
+To access the Network or some of the resources it offers, you may be asked to provide an Ethereum wallet address (a "**Wallet**"). It is your sole responsibility to maintain the security of your Wallet. If you lose access to your Wallet, a private key, password, or other method of securing your Wallet, any funds may be irretrievable, and we will be unable to assist you in any way. You hereby irrevocably waive, release and discharge all claims, whether known or unknown to you, against us, our affiliates and their respective shareholders, members, directors, officers, employees, agents and representatives related to your use of any Wallet software, associated loss of funds, transaction failures, or any other defects that arise in the course of your use of your Wallet, including any losses that may obtain as a result of any failure in smart contracts made available on the Network. By using the Network, you agree to be fully, independently and personally liable for each transaction made on the Network by you, and you must make sure that you are the only person with access to your Wallet at all times. You hereby accept responsibility for any activity transacted on the Network through your Wallet.
+
+We will use commercially reasonable technical and physical safeguards to make the Network securely available to its users. However, given the inherent risk of transmitting information over the internet and the relatively new and untested nature of decentralized finance, we will not be liable if for any reason all or any part of the Network is unavailable at any time or for any period. You alone are responsible for evaluating any code provided by or used on the Network. From time to time, we may restrict access to some parts of the Network, or the entire Network, to users. You are responsible for making all arrangements necessary for you to have access to the Network and ensuring that all persons who access the Network through your internet connection are aware of these Terms of Use and comply with them.
+
+It is a condition of your use of the Network that all the information you provide on the Network is correct, current and complete. You agree that all information you provide to this Network or otherwise, including but not limited to through the use of any interactive features on the Network, is governed by our [_Privacy Policy_](https://tbtc.network/privacy-policy), and you consent to all actions we take with respect to your information consistent with our Privacy Policy.
+
+## Fees
+
+Some services on the Network involve the use of blockchains, including the Ethereum blockchain, which may require that you pay a fee, such as "**Ethereum Gas Charges**", for the computational resources required to perform a transaction. You acknowledge and agree that the Company has no control over these fees, including: 
+
+- (a) any Ethereum blockchain transactions;
+- (b) the method of payment of any Ethereum Gas Charges; or 
+- (c) any actual payments of Ethereum Gas Charges.
+
+Accordingly, you must ensure that you have a sufficient balance of digital assets, such as Ether, stored at your Wallet to complete any transaction on the Ethereum blockchain network before initiating such transactions. You may be subject to additional fees and charges, including fees required to access certain smart contracts. You acknowledge that such fees may be adjusted from time to time by us or by other users who set the terms of their own smart contracts. If you do not agree with the fees charged for Network functionality, do not use or access the Network.
+
+The use of certain smart contract functionality on the Network may require the purchase of Keep Digital Assets, the payment of fees or the posting of collateral in other types of Digital Assets as determined by the creator of such smart contract. You agree that any such fees or requirements are reasonable, and your use of the Network or any related smart contracts shall constitute your acceptance of such fees or requirements.
+
+Notwithstanding anything in this Agreement to the contrary, it is your sole responsibility to determine whether, and to what extent, any taxes apply to any transactions you conduct through the Network, and to withhold, collect, report and remit the correct amount of taxes to the appropriate tax authorities. You agree to indemnify and hold us harmless for your failure to pay any taxes, including any penalties, duties and interest, imposed by any governmental authority.
+
+**Risks.** Use of the Network may carry financial risk. Digital Assets are a novel and relatively experimental technology. Their value, if any, can fluctuate with great volatility, and transactions conducted with Digital Assets are irreversible. The use of Digital Assets in decentralized finance is inherently risky, and you acknowledge and agree that you are accessing and using the Network at your own risk. The risk of loss due to market volatility and malfeasance by other users of the Network can be substantial. Digital Assets and smart contracts are typically described using extremely technical language that is difficult to understand and requires a deep knowledge of cryptography and computer science. Dapps made available on the Network may have inherent design flaws that have not been detected in testing or may not perform as expected in conjunction with third-party technology or high-volume use. You should carefully consider whether you have sufficient understanding of the technology before accessing or using the Network.
+
+By accessing or using the Network, you hereby represent that you have the requisite knowledge and experience to evaluate the risk of the technology you are using and any transactions you undertake, and you accept the risk that the Network might not function as anticipated and that you might lose access to your Digital Assets temporarily or permanently. The Network encourages the creation of third-party Dapps and smart contract technology, but the availability of third-party Dapps and smart contract technology on the Network is not an endorsement by us of that technology. You acknowledge and agree that the Company is not a party to the smart contracts offered on the Network and that the contract counterparty to any smart contracts you enter will likely be unknown to you.
+
+You acknowledge that the Network runs on top of the decentralized Ethereum blockchain and that we have no control over the availability of the Ethereum blockchain or the price of the Digital Asset, ETH. The Ethereum protocol is open source, and anyone can use, copy or make modifications to the protocol known as "**Forks**"which could materially affect the operation of the Ethereum blockchain and thus, the Network. In the event of a Fork, you acknowledge and agree that we may temporarily or permanently suspend our operations and that we bear no liability for losses resulting from a Fork in the Ethereum blockchain.
+
+More specifically, if you are a user of any one of several smart contracts on the Network, you may be required to post collateral or pay a fee. You acknowledge that under certain circumstances, market fluctuation could require you to increase the amount of collateral required to fulfill your performance obligations under the smart contract or your collateral could diminish in value or be lost altogether. Under no circumstances will the operation of all or any portion of the Network be deemed to create a relationship that includes the provision or tendering of investment advice.
+
+The Network may become the target of sophisticated hacking attempts, cyber attacks, dramatic fluctuations in use or other technical or operational challenges that could affect its availability or ability to function properly. You accept the risk of any delays or transaction failures resulting from such interference with the Network or any third-party services connected to or operating in conjunction with the Network including other operators of decentralized networks, platforms or Dapps. You further acknowledge that decentralized lending and borrowing protocols that ultimately allow the use of Digital Assets created on our platform have no legal obligation to provide software development to or maintain their protocols, and you should not expect that their services will continue or be available at any particular time. We are not responsible for the availability of or maintenance to lending or borrowing protocols that allow interaction, through smart contracts or otherwise, with the Keep Network or Keep Digital Assets.
+
+You acknowledge that Company is a non-custodial provider of Network services. We do not provide custody services, control or manage your Digital Assets in any manner whatsoever. The Network exists in a decentralized environment through which functionality can be autonomously directly accessed by you without any involvement or actions by Company or any third-party. Use of the Network requires the use of ERC 20 compatible Wallet(s). It is your responsibility to maintain access to and the security of your Wallet. If you fail to secure your Wallet properly, you could lose access to the contents of your Wallet and you will no longer be able to access or use some Network features.
+
+In many jurisdictions, the regulatory frameworks imposed by governmental authorities over the use and sale of cryptocurrencies or Digital Assets are uncertain. Changes in regulations and policies may affect your use of the Network in your jurisdiction, and you are responsible for consulting with legal counsel and complying with all applicable laws in your jurisdiction.
+
+The Network may rely on the use of third-party platforms, exchanges, Dapps, oracles or other mechanisms to facilitate your use of the Network. We do not control the availability of those platforms, and your access to and use of the Network could be affected by changes in those platforms which are beyond our control.
+
+## Intellectual Property Rights
+
+You must not delete or alter any copyright, trademark or other proprietary rights notices from copies of materials from this site. The smart contracts and software provided by us to the Network are made available to you under the [MIT open source license](https://github.com/keep-network/keep-ecdsa/blob/master/LICENSE), and the documentation and source code are available at [https://github.com/keep-network](https://github.com/keep-network). Other third-party technology provided to the Network is owned by the third-party provider of such technology or is made available subject to the license identified with the technology.
+
+The Keep name, Company logo and other related trademarks or service marks are the exclusive property of the Company and may not be used without our prior written consent. If you breach these Terms of Use, your right to use the Network will cease immediately and you must, at our option, return or destroy any copies of the materials you have made. No right, title or interest in or to the Network or any content on the Network is transferred to you, and all rights not expressly granted are reserved by the Company. Any use of the Network not expressly permitted by these Terms of Use is a breach of these Terms of Use and may violate copyright, trademark and other laws.
+
+## Prohibited Uses
+
+You may use the Network only for lawful purposes and in accordance with these Terms of Use. You agree not to use the Network:
+
+- In any way that violates any applicable federal, state, local or international law or regulation (including, without limitation, any laws regarding the export of data or software to and from the US or other countries).
+- For the purpose of exploiting, harming or attempting to exploit or harm minors in any way by exposing them to inappropriate content, asking for personally identifiable information or otherwise.
+- To attempt to circumvent any Network security or access controls or to interfere with the operation of the Network.
+- To impersonate or attempt to impersonate the Company, a Company employee, another user or any other person or entity (including, without limitation, by using e-mail addresses or wallet addresses associated with any of the foregoing).
+- To transmit or exchange Digital Assets that are the direct or indirect proceeds of any illegal, criminal or fraudulent behavior including terrorism.
+- In any manner that could disable, overburden, damage, or impair the site or interfere with any other party's use of the Network, including their ability to engage in real time activities through the Network.
+- Use any robot, spider or other automatic device, process or means to access the Network for any purpose, including monitoring or copying any of the material on the Network.
+- Use any manual process to monitor or copy any of the material on the Network or for any other unauthorized purpose without our prior written consent.
+- Use any device, software or routine that interferes with the proper working of the Network.
+- Introduce any viruses, trojan horses, worms, logic bombs or other material which is malicious or technologically harmful.
+- Otherwise attempt to interfere with the proper working of the Network.
+
+## User Contributions
+
+The Network may contain links to social media, message boards, chat rooms, personal web pages or profiles, forums, bulletin boards, FAQs and other interactive features (collectively, "**Interactive Services**") that allow users to post, submit, publish, display, advise or transmit to other users or other persons (hereinafter, "**post**") content or materials (collectively, "**User Contributions**") on or through the Network.
+
+All User Contributions must comply with the Content Standards set out in these Terms of Use. Any User Contribution you post to the site will be considered non-confidential and non-proprietary. By providing any User Contribution on the Network, you grant us and our affiliates and service providers, and each of their and our respective licensees, successors and assigns the right to use, reproduce, modify, perform, display, distribute and otherwise disclose to third parties any such material for any purpose.
+
+You represent and warrant that:
+
+- You own or control all rights in and to the User Contributions and have the right to grant the license granted above to us and our affiliates and service providers, and each of their and our respective licensees, successors and assigns.
+- All of your User Contributions do and will comply with these Terms of Use.
+
+You understand and acknowledge that you are responsible for any User Contributions you submit or contribute, and you, not the Company, have fully responsibility for such content, including its legality, reliability, accuracy and appropriateness. We are not responsible, or liable to any third party, for the content or accuracy of any User Contributions posted by you or any other user of the Network.
+
+## Monitoring and Enforcement; Termination
+
+We have the right to:
+
+- Remove or refuse to post any User Contributions for any or no reason in our sole discretion.
+- Take any action with respect to any User Contribution that we deem necessary or appropriate in our sole discretion, including if we believe that such User Contribution violates the Terms of Use, including the Content Standards, infringes any intellectual property right or other right of any person or entity, threatens the personal safety of users of the Network or the public or could create liability for the Company.
+- Disclose information about you to any third party who claims that material posted by you violates their rights, including their intellectual property rights or their right to privacy.
+- Take appropriate legal action, including without limitation, referral to law enforcement, for any illegal or unauthorized use of the Network.
+- Terminate or suspend your access to all or part of the Network for any or no reason, including without limitation, any violation of these Terms of Use.
+
+Without limiting the foregoing, we have the right to fully cooperate with any law enforcement authorities or court order requesting or directing us to disclose the identity or other information of anyone using or posting any materials on or through the Network.
+
+However, we do not undertake to review material before it is posted on or through the Network and cannot ensure prompt removal of objectionable material after it has been posted. Accordingly, we assume no liability for any action or inaction regarding transmissions, communications or content provided by any user or third party. We have no liability or responsibility to anyone for performance or nonperformance of the activities described in this section.
+
+## Content Standards
+
+These content standards apply to any and all User Contributions and use of Interactive Services. User Contributions must in their entirety comply with all applicable federal, state, local and international laws and regulations. Without limiting the foregoing, User Contributions must not:
+
+- Contain any material which is defamatory, obscene, indecent, abusive, offensive, harassing, violent, hateful, inflammatory or otherwise objectionable.
+- Promote sexually explicit or pornographic material, violence, or discrimination based on race, sex, religion, nationality, disability, sexual orientation or age.
+- Infringe any patent, trademark, trade secret, copyright or other intellectual property or other rights of any other person.
+- Violate the legal rights (including the rights of publicity and privacy) of others or contain any material that could give rise to any civil or criminal liability under applicable laws or regulations or that otherwise may be in conflict with these Terms of Use and our [Privacy Policy](https://tbtc.network/privacy-policy).
+- Be likely to deceive any person.
+- Promote any illegal activity, or advocate, promote or assist any unlawful act.
+- Cause annoyance, inconvenience or needless anxiety or be likely to upset, embarrass, alarm or annoy any other person.
+- Impersonate any person or misrepresent your identity or affiliation with any person or organization.
+- Involve commercial activities or sales, such as contests, sweepstakes and other sales promotions, barter or advertising.
+- Give the impression that they emanate from or are endorsed by us or any other person or entity, if this is not the case.
+
+## Reliance on Information Posted
+
+The information presented on or through the Network is made available solely for general information purposes. We do not warrant the accuracy, completeness or usefulness of this information. Any reliance you place on such information is strictly at your own risk. We disclaim all liability and responsibility arising from any reliance placed on such materials by you or any other user of the Network, or by anyone who may be informed of any of its contents.
+
+This Network may include or link to content provided by third parties, including materials provided by other users, smart contract creators, third-party licensors, syndicators, aggregators, reporting services, FAQ providers and/or "how to"manuals. All statements and/or opinions expressed in such materials, and all articles and responses to questions and other content, other than the content provided by the Company, are solely the opinions and the responsibility of the person or entity providing those materials. These materials do not necessarily reflect the opinion of the Company. We are not responsible, or liable to you or any third party, for the content or accuracy of any materials provided by any third parties.
+
+## Changes to the Network
+
+We may update the content on this Network from time to time, but its content is not necessarily complete or up-to-date. We reserve the right to withdraw or amend this Network, and any service or functionality, including smart contract functionality, on the Network in our sole discretion without notice. Any of the material on the Network may be out of date at any given time, and we are under no obligation to update such material. You acknowledge that the software protocols comprising the Network are open source, and over time, by consensus of Network users or by actions of third parties beyond our controls, may be modified, copied or reproduced in different form. As such we are not responsible for the operation of the underlying protocols and make no guarantee of their functionality, security or availability. In the event of a change in the operation of the Network, you agree we may temporarily or permanently suspend our operations without liability to you.
+
+## Information About You and Your Visits to the Network
+
+All information we collect on this Network is subject to our Privacy Policy. By using the Network, you consent to all actions taken by us with respect to your information in compliance with the Privacy Policy.
+
+## Third-Party Terms and Conditions
+
+Additional terms and conditions may apply to specific portions, services or features of the Network provided by third parties including Dapps and smart contracts, either alone or in conjunction with the functionality provided by us. The use of such services or features shall be governed by the terms of use associated with them, and all such additional terms of use are hereby incorporated by this reference into these Terms of Use. We accept no liability or responsibility for any third-party functionality or any of our open source functionality that has been modified by third parties.
+
+## Links from the Network
+
+If the Network contains links to other sites and resources provided by third parties, these links are provided for your convenience only. We have no control over the contents of those sites or resources and accept no responsibility for them or for any loss or damage that may arise from your use of them. If you decide to access any of the third party sites linked to this Network, you do so entirely at your own risk and subject to the terms and conditions of use for such Networks.
+
+## Geographic Restrictions
+
+Access to the Network may not be legal by certain persons or in certain countries. You are responsible for compliance with all applicable laws in your jurisdiction.
+
+## Disclaimer of Warranties
+
+WE WILL NOT BE LIABLE FOR ANY LOSS OR DAMAGE CAUSED BY A DISTRIBUTED DENIAL-OF-SERVICE ATTACK, HACKS, VIRUSES OR OTHER TECHNOLOGICALLY HARMFUL MATERIAL THAT MAY INFECT YOUR COMPUTER EQUIPMENT, COMPUTER PROGRAMS, DATA OR OTHER PROPRIETARY MATERIAL DUE TO YOUR USE OF THE NETWORK OR ANY SERVICES OR ITEMS OBTAINED THROUGH THE NETWORK, ANY THIRD PARTY LINKS (INCLUDING BUT NOT LIMITED TO SMART CONTRACTS FAQS OR OTHER MATERIALS) ACCESSED THROUGH OR IN CONJUNCTION WITH THE NETWORK, OR ON ANY NETWORK LINKED TO IT.
+
+YOUR USE OF THE NETWORK, ITS CONTENT AND ANY SERVICES OR ITEMS OBTAINED THROUGH THE NETWORK IS AT YOUR OWN RISK. THE NETWORK, ITS CONTENT AND ANY SERVICES OR ITEMS OBTAINED THROUGH THE NETWORK ARE PROVIDED ON AN "AS IS"AND "AS AVAILABLE"BASIS, WITHOUT ANY WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED. NEITHER THE COMPANY NOR ANY PERSON ASSOCIATED WITH THE COMPANY MAKES ANY WARRANTY OR REPRESENTATION WITH RESPECT TO THE COMPLETENESS, SECURITY, RELIABILITY, QUALITY, ACCURACY OR AVAILABILITY OF THE NETWORK. WITHOUT LIMITING THE FOREGOING, NEITHER THE COMPANY NOR ANYONE ASSOCIATED WITH THE COMPANY REPRESENTS OR WARRANTS THAT THE NETWORK, ITS CONTENT OR ANY SERVICES OR ITEMS OBTAINED THROUGH THE NETWORK WILL BE ACCURATE, RELIABLE, ERROR-FREE OR UNINTERRUPTED, THAT DEFECTS WILL BE CORRECTED, THAT OUR SITE OR THE SERVER THAT MAKES IT AVAILABLE ARE FREE OF VIRUSES OR OTHER HARMFUL COMPONENTS OR THAT THE NETWORK OR ANY SERVICES OR ITEMS OBTAINED THROUGH THE NETWORK WILL OTHERWISE MEET YOUR NEEDS OR EXPECTATIONS.
+
+YOU HEREBY IRREVOCABLY WAIVE, RELEASE AND DISCHARGE ALL CLAIMS, WHETHER KNOWN OR UNKNOWN TO YOU, AGAINST US, OUR AFFILIATES AND THEIR RESPECTIVE SHAREHOLDERS, MEMBERS, DIRECTORS, OFFICERS, EMPLOYEES, AGENTS AND REPRESENTATIVES RELATED TO YOUR USE OF ANY WALLET SOFTWARE, ASSOCIATED LOSS OF FUNDS, TRANSACTION FAILURES, OR ANY OTHER DEFECTS THAT ARISE IN THE COURSE OF YOUR USE OF YOUR WALLET. THE COMPANY HEREBY DISCLAIMS ALL WARRANTIES OF ANY KIND, WHETHER EXPRESS OR IMPLIED, STATUTORY OR OTHERWISE, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF MERCHANTABILITY, NON-INFRINGEMENT AND FITNESS FOR PARTICULAR PURPOSE.
+
+THE FOREGOING DOES NOT AFFECT ANY WARRANTIES WHICH CANNOT BE EXCLUDED OR LIMITED UNDER APPLICABLE LAW.
+
+## Limitation on Liability
+
+IN NO EVENT WILL THE COMPANY, ITS AFFILIATES OR THEIR LICENSORS, SERVICE PROVIDERS, EMPLOYEES, AGENTS, OFFICERS OR DIRECTORS BE LIABLE FOR DAMAGES OF ANY KIND, UNDER ANY LEGAL THEORY, ARISING OUT OF OR IN CONNECTION WITH YOUR USE, OR INABILITY TO USE, THE NETWORK, ANY NETWORKS LINKED TO IT, ANY SMART CONTRACTS OR DISTRIBUTED APPLICATIONS EXISTING ON OR CONNECTING TO THE NETWORK, ANY LOSS OF FUNDS OR COLLATERAL, ANY CONTENT ON THE NETWORK OR SUCH OTHER NETWORKS OR ANY SERVICES OR ITEMS OBTAINED THROUGH THE NETWORK OR SUCH OTHER NETWORKS, INCLUDING ANY DIRECT, INDIRECT, SPECIAL, INCIDENTAL, CONSEQUENTIAL OR PUNITIVE DAMAGES, INCLUDING BUT NOT LIMITED TO, PERSONAL INJURY, PAIN AND SUFFERING, EMOTIONAL DISTRESS, LOSS OF REVENUE, LOSS OF PROFITS, LOSS OF BUSINESS OR ANTICIPATED SAVINGS, LOSS OF USE, LOSS OF GOODWILL, LOSS OF DATA, AND WHETHER CAUSED BY TORT (INCLUDING NEGLIGENCE), BREACH OF CONTRACT OR OTHERWISE, EVEN IF FORESEEABLE. UNDER NO CIRCUMSTANCES WILL WE BE RESPONSIBLE FOR ANY DAMAGES, LOSS OR INJURY RESULTING FROM HACKING, TAMPERING OR OTHER UNAUTHORIZED ACCESS OR USE OF THE NETWORK OR ITS CONTENTS.
+
+THE FOREGOING DOES NOT AFFECT ANY LIABILITY WHICH CANNOT BE EXCLUDED OR LIMITED UNDER APPLICABLE LAW.
+
+## Indemnification
+
+You agree to defend, indemnify and hold harmless the Company, its affiliates, licensors and service providers, and its and their respective officers, directors, employees, contractors, agents, licensors, suppliers, successors and assigns from and against any claims, liabilities, damages, judgments, awards, losses, costs, expenses, debts and fees (including reasonable attorneys' fees) arising out of or relating to: your use of or access to the Network; your violation of any third party right; the provision by you of any false or misleading information; your violation of any law, rule or regulation; your violation of these Terms of Use; your willful misconduct; or your use of the Network, including, but not limited to, your User Contributions, any use of the Network's content, services and products other than as expressly authorized in these Terms of Use or your use of any information obtained from the Network.
+
+## Release of Claims
+
+You acknowledge that the Network (including without limitation the smart contracts) and your use of the Network contain certain risks, including without limitation the following risks:  any smart contracts you interact with are entirely your own responsibility and your own liability, and we are not a party to the smart contracts; At any time, your access to your Digital Assets may be suspended or terminated or there may be a delay in your access or use of your Digital Assets which may result in the Digital Assets diminishing in value or you being unable to complete a smart contract; if your collateral declines such that your collateral is no longer sufficient to secure your position as a signer or depositor that a liquidation auction may not produce sufficient revenue to return your collateral, or other users may seize your collateral to close out your account; and the Network and related smart contracts may be suspended or terminated for any or no reason, which may limit your access to your Digital Assets. You assume all risk in connection with your access to and use of the Network and its smart contracts, and you waive and release us from any and all liability, claims, causes of action or damages arising from or in any way related to your use of the Network or the smart contracts.
+
+## Governing Law and Jurisdiction
+
+All matters relating to the Network and these Terms of Use and any dispute or claim arising therefrom or related thereto (in each case, including non-contractual disputes or claims), shall be governed by and construed in accordance with the internal laws of the Cayman Islands without giving effect to any choice or conflict of law provision or rule.
+
+Any legal suit, action or proceeding arising out of, or related to, these Terms of Use or the Network shall be instituted exclusively in the courts of the Cayman Islands. You waive any and all objections to the exercise of jurisdiction over you by such courts and to venue in such courts.
+
+## Arbitration
+
+At Company's sole discretion, it may require You to submit any disputes arising from the use of these Terms of Use or the Network, including disputes arising from or concerning their interpretation, violation, invalidity, non-performance, or termination, to final and binding arbitration under the Rules of Arbitration of the American Arbitration Association applying Cayman Island law.
+
+## Limitation on Time to File Claims
+
+ANY CAUSE OF ACTION OR CLAIM YOU MAY HAVE ARISING OUT OF OR RELATING TO THESE TERMS OF USE OR THE NETWORK MUST BE COMMENCED WITHIN ONE (1) YEAR AFTER THE CAUSE OF ACTION ACCRUES, OTHERWISE, SUCH CAUSE OF ACTION OR CLAIM IS PERMANENTLY BARRED.
+
+## Waiver and Severability
+
+No waiver of by the Company of any term or condition set forth in these Terms of Use shall be deemed a further or continuing waiver of such term or condition or a waiver of any other term or condition, and any failure of the Company to assert a right or provision under these Terms of Use shall not constitute a waiver of such right or provision.
+
+If any provision of these Terms of Use is held by a court or other tribunal of competent jurisdiction to be invalid, illegal or unenforceable for any reason, such provision shall be eliminated or limited to the minimum extent such that the remaining provisions of the Terms of Use will continue in full force and effect.
+
+## Entire Agreement
+
+The Terms of Use and our Privacy Policy constitute the sole and entire agreement between you and Keep SECZ with respect to the Network and supersede all prior and contemporaneous understandings, agreements, representations and warranties, both written and oral, with respect to the Network.
+
+## Your Comments and Concerns
+
+This Network is initially operated by Keep SEZC.
+
+All feedback, comments, requests for technical support and other communications relating to the Network should be directed to: [legal@keep.network](mailto:legal@keep.network).
+
+0142785.0724991 4828-0651-3078v3

--- a/src/pages/terms-of-use/index.ru.md
+++ b/src/pages/terms-of-use/index.ru.md
@@ -1,0 +1,204 @@
+---
+template: legal-page
+path: /terms-of-use
+title: tBTC Network Terms of Use
+---
+Last Modified: May 1, 2020
+
+## Acceptance of the Terms of Use
+
+These terms of use are entered into by and between You and Keep SECZ, a Cayman Islands special economic zone company ("**Company**", "**we**" or "**us**"). The following terms and conditions, together with any documents they expressly incorporate by reference (collectively, these "**Terms of Use**"), govern your access to and use of the network located at [tbtc.network](https://tbtc.network/) as well as any content, functionality, smart contracts, distributed applications ("Dapps") and services offered on or through the tBTC network (collectively, the "**Network**"). The Network is currently administered by the Company using open source protocols; however, we intend over time for the Network and the network protocol to become decentralized and governed entirely by the community of its users in whatever manner they determine.
+
+Please read the Terms of Use carefully before you start to use the Network. **By using the Network or by clicking to accept or agree to the Terms of Use when this option is made available to you, you accept and agree to be bound and abide by these Terms of Use and our [Privacy Policy](/privacy-policy), incorporated herein by reference.** If you do not want to agree to these Terms of Use or the [Privacy Policy](/privacy-policy), you must not access or use the Network.
+
+This Network is offered and available to users who are 18 years of age or older who are not residents of countries named on the [US Department of the Treasury Sanctions list](https://www.treasury.gov/resource-center/sanctions/Programs/Pages/Programs.aspx) or named on the Office of Foreign Asset Control's list of [Specially Designated Nationals and Blocked Persons](https://www.treasury.gov/resource-center/sanctions/SDN-List/Pages/default.aspx) ("SDN List"). If the user is an organization, you affirm you have the right, power and authority to enter into this agreement on behalf of the organization and bind the organization to its terms. If you do not agree to the terms of this agreement, you must not use the Network or any of our services. By using this Network, you represent and warrant that you are of legal age to form a binding contract with the Company and meet all of the foregoing eligibility requirements. You represent that you are legally permitted to use the Network in your jurisdiction including owning Digital Assets and interacting with the Network in any way.If you do not meet all of these requirements, you must not access or use the Network. Without limiting the foregoing, by using the Network, you acknowledge and understand that laws regarding financial instruments, which sometimes include cryptographic tokens, also known as "**Digital Assets**", and decentralized finance may vary from jurisdiction to jurisdiction, and it is your obligation alone to ensure that you fully comply with any law, regulation or directive, relevant to your jurisdiction with regard to the use of the Network. You further represent and warrant that you will not use the Network or access its smart contract functionality if the laws of your country of residency or establishment prohibit you from doing so in accordance with this agreement. For the avoidance of doubt, the ability to access the Network does not necessarily mean that the Network, or your activities through it, are legal under the laws, regulations or directives relevant to your jurisdiction. All of the Network or the services made available through the Network may not be available to all users, and we reserve the right to assess or reassess at any time your eligibility to use all or part of our Network. The availability of the Network does not constitute, and may not be used for the purposes of, an offer or solicitation to anyone in any jurisdiction in which such offer or solicitation is not authorized, or to any person to whom it is unlawful to make such an offer or solicitation. By accessing or using the Network, you explicitly agree that the smart contracts built into the Dapps that comprise the Network are legally binding and enforceable upon you and the contract counterparty.
+
+## Changes to the Terms of Use
+
+We, or in the future, a decentralized governing body, may revise and update these Terms of Use from time to time in our sole discretion. All changes are effective immediately when we post them and apply to all access to and use of the Network thereafter. However, any changes to the dispute resolution provisions set forth in Governing Law and Jurisdiction will not apply to any disputes for which the parties have actual notice on or prior to the date the change is posted on the Network.
+
+Your continued use of the Network following the posting of revised Terms of Use means that you accept and agree to the changes. You are expected to check this page each time you access this Network so you are aware of any changes, as they are binding on you.
+
+## Accessing the Network and Account Security
+
+To access the Network or some of the resources it offers, you may be asked to provide an Ethereum wallet address (a "**Wallet**"). It is your sole responsibility to maintain the security of your Wallet. If you lose access to your Wallet, a private key, password, or other method of securing your Wallet, any funds may be irretrievable, and we will be unable to assist you in any way. You hereby irrevocably waive, release and discharge all claims, whether known or unknown to you, against us, our affiliates and their respective shareholders, members, directors, officers, employees, agents and representatives related to your use of any Wallet software, associated loss of funds, transaction failures, or any other defects that arise in the course of your use of your Wallet, including any losses that may obtain as a result of any failure in smart contracts made available on the Network. By using the Network, you agree to be fully, independently and personally liable for each transaction made on the Network by you, and you must make sure that you are the only person with access to your Wallet at all times. You hereby accept responsibility for any activity transacted on the Network through your Wallet.
+
+We will use commercially reasonable technical and physical safeguards to make the Network securely available to its users. However, given the inherent risk of transmitting information over the internet and the relatively new and untested nature of decentralized finance, we will not be liable if for any reason all or any part of the Network is unavailable at any time or for any period. You alone are responsible for evaluating any code provided by or used on the Network. From time to time, we may restrict access to some parts of the Network, or the entire Network, to users. You are responsible for making all arrangements necessary for you to have access to the Network and ensuring that all persons who access the Network through your internet connection are aware of these Terms of Use and comply with them.
+
+It is a condition of your use of the Network that all the information you provide on the Network is correct, current and complete. You agree that all information you provide to this Network or otherwise, including but not limited to through the use of any interactive features on the Network, is governed by our [_Privacy Policy_](https://tbtc.network/privacy-policy), and you consent to all actions we take with respect to your information consistent with our Privacy Policy.
+
+## Fees
+
+Some services on the Network involve the use of blockchains, including the Ethereum blockchain, which may require that you pay a fee, such as "**Ethereum Gas Charges**", for the computational resources required to perform a transaction. You acknowledge and agree that the Company has no control over these fees, including: 
+
+- (a) any Ethereum blockchain transactions;
+- (b) the method of payment of any Ethereum Gas Charges; or 
+- (c) any actual payments of Ethereum Gas Charges.
+
+Accordingly, you must ensure that you have a sufficient balance of digital assets, such as Ether, stored at your Wallet to complete any transaction on the Ethereum blockchain network before initiating such transactions. You may be subject to additional fees and charges, including fees required to access certain smart contracts. You acknowledge that such fees may be adjusted from time to time by us or by other users who set the terms of their own smart contracts. If you do not agree with the fees charged for Network functionality, do not use or access the Network.
+
+The use of certain smart contract functionality on the Network may require the purchase of Keep Digital Assets, the payment of fees or the posting of collateral in other types of Digital Assets as determined by the creator of such smart contract. You agree that any such fees or requirements are reasonable, and your use of the Network or any related smart contracts shall constitute your acceptance of such fees or requirements.
+
+Notwithstanding anything in this Agreement to the contrary, it is your sole responsibility to determine whether, and to what extent, any taxes apply to any transactions you conduct through the Network, and to withhold, collect, report and remit the correct amount of taxes to the appropriate tax authorities. You agree to indemnify and hold us harmless for your failure to pay any taxes, including any penalties, duties and interest, imposed by any governmental authority.
+
+**Risks.** Use of the Network may carry financial risk. Digital Assets are a novel and relatively experimental technology. Their value, if any, can fluctuate with great volatility, and transactions conducted with Digital Assets are irreversible. The use of Digital Assets in decentralized finance is inherently risky, and you acknowledge and agree that you are accessing and using the Network at your own risk. The risk of loss due to market volatility and malfeasance by other users of the Network can be substantial. Digital Assets and smart contracts are typically described using extremely technical language that is difficult to understand and requires a deep knowledge of cryptography and computer science. Dapps made available on the Network may have inherent design flaws that have not been detected in testing or may not perform as expected in conjunction with third-party technology or high-volume use. You should carefully consider whether you have sufficient understanding of the technology before accessing or using the Network.
+
+By accessing or using the Network, you hereby represent that you have the requisite knowledge and experience to evaluate the risk of the technology you are using and any transactions you undertake, and you accept the risk that the Network might not function as anticipated and that you might lose access to your Digital Assets temporarily or permanently. The Network encourages the creation of third-party Dapps and smart contract technology, but the availability of third-party Dapps and smart contract technology on the Network is not an endorsement by us of that technology. You acknowledge and agree that the Company is not a party to the smart contracts offered on the Network and that the contract counterparty to any smart contracts you enter will likely be unknown to you.
+
+You acknowledge that the Network runs on top of the decentralized Ethereum blockchain and that we have no control over the availability of the Ethereum blockchain or the price of the Digital Asset, ETH. The Ethereum protocol is open source, and anyone can use, copy or make modifications to the protocol known as "**Forks**"which could materially affect the operation of the Ethereum blockchain and thus, the Network. In the event of a Fork, you acknowledge and agree that we may temporarily or permanently suspend our operations and that we bear no liability for losses resulting from a Fork in the Ethereum blockchain.
+
+More specifically, if you are a user of any one of several smart contracts on the Network, you may be required to post collateral or pay a fee. You acknowledge that under certain circumstances, market fluctuation could require you to increase the amount of collateral required to fulfill your performance obligations under the smart contract or your collateral could diminish in value or be lost altogether. Under no circumstances will the operation of all or any portion of the Network be deemed to create a relationship that includes the provision or tendering of investment advice.
+
+The Network may become the target of sophisticated hacking attempts, cyber attacks, dramatic fluctuations in use or other technical or operational challenges that could affect its availability or ability to function properly. You accept the risk of any delays or transaction failures resulting from such interference with the Network or any third-party services connected to or operating in conjunction with the Network including other operators of decentralized networks, platforms or Dapps. You further acknowledge that decentralized lending and borrowing protocols that ultimately allow the use of Digital Assets created on our platform have no legal obligation to provide software development to or maintain their protocols, and you should not expect that their services will continue or be available at any particular time. We are not responsible for the availability of or maintenance to lending or borrowing protocols that allow interaction, through smart contracts or otherwise, with the Keep Network or Keep Digital Assets.
+
+You acknowledge that Company is a non-custodial provider of Network services. We do not provide custody services, control or manage your Digital Assets in any manner whatsoever. The Network exists in a decentralized environment through which functionality can be autonomously directly accessed by you without any involvement or actions by Company or any third-party. Use of the Network requires the use of ERC 20 compatible Wallet(s). It is your responsibility to maintain access to and the security of your Wallet. If you fail to secure your Wallet properly, you could lose access to the contents of your Wallet and you will no longer be able to access or use some Network features.
+
+In many jurisdictions, the regulatory frameworks imposed by governmental authorities over the use and sale of cryptocurrencies or Digital Assets are uncertain. Changes in regulations and policies may affect your use of the Network in your jurisdiction, and you are responsible for consulting with legal counsel and complying with all applicable laws in your jurisdiction.
+
+The Network may rely on the use of third-party platforms, exchanges, Dapps, oracles or other mechanisms to facilitate your use of the Network. We do not control the availability of those platforms, and your access to and use of the Network could be affected by changes in those platforms which are beyond our control.
+
+## Intellectual Property Rights
+
+You must not delete or alter any copyright, trademark or other proprietary rights notices from copies of materials from this site. The smart contracts and software provided by us to the Network are made available to you under the [MIT open source license](https://github.com/keep-network/keep-ecdsa/blob/master/LICENSE), and the documentation and source code are available at [https://github.com/keep-network](https://github.com/keep-network). Other third-party technology provided to the Network is owned by the third-party provider of such technology or is made available subject to the license identified with the technology.
+
+The Keep name, Company logo and other related trademarks or service marks are the exclusive property of the Company and may not be used without our prior written consent. If you breach these Terms of Use, your right to use the Network will cease immediately and you must, at our option, return or destroy any copies of the materials you have made. No right, title or interest in or to the Network or any content on the Network is transferred to you, and all rights not expressly granted are reserved by the Company. Any use of the Network not expressly permitted by these Terms of Use is a breach of these Terms of Use and may violate copyright, trademark and other laws.
+
+## Prohibited Uses
+
+You may use the Network only for lawful purposes and in accordance with these Terms of Use. You agree not to use the Network:
+
+- In any way that violates any applicable federal, state, local or international law or regulation (including, without limitation, any laws regarding the export of data or software to and from the US or other countries).
+- For the purpose of exploiting, harming or attempting to exploit or harm minors in any way by exposing them to inappropriate content, asking for personally identifiable information or otherwise.
+- To attempt to circumvent any Network security or access controls or to interfere with the operation of the Network.
+- To impersonate or attempt to impersonate the Company, a Company employee, another user or any other person or entity (including, without limitation, by using e-mail addresses or wallet addresses associated with any of the foregoing).
+- To transmit or exchange Digital Assets that are the direct or indirect proceeds of any illegal, criminal or fraudulent behavior including terrorism.
+- In any manner that could disable, overburden, damage, or impair the site or interfere with any other party's use of the Network, including their ability to engage in real time activities through the Network.
+- Use any robot, spider or other automatic device, process or means to access the Network for any purpose, including monitoring or copying any of the material on the Network.
+- Use any manual process to monitor or copy any of the material on the Network or for any other unauthorized purpose without our prior written consent.
+- Use any device, software or routine that interferes with the proper working of the Network.
+- Introduce any viruses, trojan horses, worms, logic bombs or other material which is malicious or technologically harmful.
+- Otherwise attempt to interfere with the proper working of the Network.
+
+## User Contributions
+
+The Network may contain links to social media, message boards, chat rooms, personal web pages or profiles, forums, bulletin boards, FAQs and other interactive features (collectively, "**Interactive Services**") that allow users to post, submit, publish, display, advise or transmit to other users or other persons (hereinafter, "**post**") content or materials (collectively, "**User Contributions**") on or through the Network.
+
+All User Contributions must comply with the Content Standards set out in these Terms of Use. Any User Contribution you post to the site will be considered non-confidential and non-proprietary. By providing any User Contribution on the Network, you grant us and our affiliates and service providers, and each of their and our respective licensees, successors and assigns the right to use, reproduce, modify, perform, display, distribute and otherwise disclose to third parties any such material for any purpose.
+
+You represent and warrant that:
+
+- You own or control all rights in and to the User Contributions and have the right to grant the license granted above to us and our affiliates and service providers, and each of their and our respective licensees, successors and assigns.
+- All of your User Contributions do and will comply with these Terms of Use.
+
+You understand and acknowledge that you are responsible for any User Contributions you submit or contribute, and you, not the Company, have fully responsibility for such content, including its legality, reliability, accuracy and appropriateness. We are not responsible, or liable to any third party, for the content or accuracy of any User Contributions posted by you or any other user of the Network.
+
+## Monitoring and Enforcement; Termination
+
+We have the right to:
+
+- Remove or refuse to post any User Contributions for any or no reason in our sole discretion.
+- Take any action with respect to any User Contribution that we deem necessary or appropriate in our sole discretion, including if we believe that such User Contribution violates the Terms of Use, including the Content Standards, infringes any intellectual property right or other right of any person or entity, threatens the personal safety of users of the Network or the public or could create liability for the Company.
+- Disclose information about you to any third party who claims that material posted by you violates their rights, including their intellectual property rights or their right to privacy.
+- Take appropriate legal action, including without limitation, referral to law enforcement, for any illegal or unauthorized use of the Network.
+- Terminate or suspend your access to all or part of the Network for any or no reason, including without limitation, any violation of these Terms of Use.
+
+Without limiting the foregoing, we have the right to fully cooperate with any law enforcement authorities or court order requesting or directing us to disclose the identity or other information of anyone using or posting any materials on or through the Network.
+
+However, we do not undertake to review material before it is posted on or through the Network and cannot ensure prompt removal of objectionable material after it has been posted. Accordingly, we assume no liability for any action or inaction regarding transmissions, communications or content provided by any user or third party. We have no liability or responsibility to anyone for performance or nonperformance of the activities described in this section.
+
+## Content Standards
+
+These content standards apply to any and all User Contributions and use of Interactive Services. User Contributions must in their entirety comply with all applicable federal, state, local and international laws and regulations. Without limiting the foregoing, User Contributions must not:
+
+- Contain any material which is defamatory, obscene, indecent, abusive, offensive, harassing, violent, hateful, inflammatory or otherwise objectionable.
+- Promote sexually explicit or pornographic material, violence, or discrimination based on race, sex, religion, nationality, disability, sexual orientation or age.
+- Infringe any patent, trademark, trade secret, copyright or other intellectual property or other rights of any other person.
+- Violate the legal rights (including the rights of publicity and privacy) of others or contain any material that could give rise to any civil or criminal liability under applicable laws or regulations or that otherwise may be in conflict with these Terms of Use and our [Privacy Policy](https://tbtc.network/privacy-policy).
+- Be likely to deceive any person.
+- Promote any illegal activity, or advocate, promote or assist any unlawful act.
+- Cause annoyance, inconvenience or needless anxiety or be likely to upset, embarrass, alarm or annoy any other person.
+- Impersonate any person or misrepresent your identity or affiliation with any person or organization.
+- Involve commercial activities or sales, such as contests, sweepstakes and other sales promotions, barter or advertising.
+- Give the impression that they emanate from or are endorsed by us or any other person or entity, if this is not the case.
+
+## Reliance on Information Posted
+
+The information presented on or through the Network is made available solely for general information purposes. We do not warrant the accuracy, completeness or usefulness of this information. Any reliance you place on such information is strictly at your own risk. We disclaim all liability and responsibility arising from any reliance placed on such materials by you or any other user of the Network, or by anyone who may be informed of any of its contents.
+
+This Network may include or link to content provided by third parties, including materials provided by other users, smart contract creators, third-party licensors, syndicators, aggregators, reporting services, FAQ providers and/or "how to"manuals. All statements and/or opinions expressed in such materials, and all articles and responses to questions and other content, other than the content provided by the Company, are solely the opinions and the responsibility of the person or entity providing those materials. These materials do not necessarily reflect the opinion of the Company. We are not responsible, or liable to you or any third party, for the content or accuracy of any materials provided by any third parties.
+
+## Changes to the Network
+
+We may update the content on this Network from time to time, but its content is not necessarily complete or up-to-date. We reserve the right to withdraw or amend this Network, and any service or functionality, including smart contract functionality, on the Network in our sole discretion without notice. Any of the material on the Network may be out of date at any given time, and we are under no obligation to update such material. You acknowledge that the software protocols comprising the Network are open source, and over time, by consensus of Network users or by actions of third parties beyond our controls, may be modified, copied or reproduced in different form. As such we are not responsible for the operation of the underlying protocols and make no guarantee of their functionality, security or availability. In the event of a change in the operation of the Network, you agree we may temporarily or permanently suspend our operations without liability to you.
+
+## Information About You and Your Visits to the Network
+
+All information we collect on this Network is subject to our Privacy Policy. By using the Network, you consent to all actions taken by us with respect to your information in compliance with the Privacy Policy.
+
+## Third-Party Terms and Conditions
+
+Additional terms and conditions may apply to specific portions, services or features of the Network provided by third parties including Dapps and smart contracts, either alone or in conjunction with the functionality provided by us. The use of such services or features shall be governed by the terms of use associated with them, and all such additional terms of use are hereby incorporated by this reference into these Terms of Use. We accept no liability or responsibility for any third-party functionality or any of our open source functionality that has been modified by third parties.
+
+## Links from the Network
+
+If the Network contains links to other sites and resources provided by third parties, these links are provided for your convenience only. We have no control over the contents of those sites or resources and accept no responsibility for them or for any loss or damage that may arise from your use of them. If you decide to access any of the third party sites linked to this Network, you do so entirely at your own risk and subject to the terms and conditions of use for such Networks.
+
+## Geographic Restrictions
+
+Access to the Network may not be legal by certain persons or in certain countries. You are responsible for compliance with all applicable laws in your jurisdiction.
+
+## Disclaimer of Warranties
+
+WE WILL NOT BE LIABLE FOR ANY LOSS OR DAMAGE CAUSED BY A DISTRIBUTED DENIAL-OF-SERVICE ATTACK, HACKS, VIRUSES OR OTHER TECHNOLOGICALLY HARMFUL MATERIAL THAT MAY INFECT YOUR COMPUTER EQUIPMENT, COMPUTER PROGRAMS, DATA OR OTHER PROPRIETARY MATERIAL DUE TO YOUR USE OF THE NETWORK OR ANY SERVICES OR ITEMS OBTAINED THROUGH THE NETWORK, ANY THIRD PARTY LINKS (INCLUDING BUT NOT LIMITED TO SMART CONTRACTS FAQS OR OTHER MATERIALS) ACCESSED THROUGH OR IN CONJUNCTION WITH THE NETWORK, OR ON ANY NETWORK LINKED TO IT.
+
+YOUR USE OF THE NETWORK, ITS CONTENT AND ANY SERVICES OR ITEMS OBTAINED THROUGH THE NETWORK IS AT YOUR OWN RISK. THE NETWORK, ITS CONTENT AND ANY SERVICES OR ITEMS OBTAINED THROUGH THE NETWORK ARE PROVIDED ON AN "AS IS"AND "AS AVAILABLE"BASIS, WITHOUT ANY WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED. NEITHER THE COMPANY NOR ANY PERSON ASSOCIATED WITH THE COMPANY MAKES ANY WARRANTY OR REPRESENTATION WITH RESPECT TO THE COMPLETENESS, SECURITY, RELIABILITY, QUALITY, ACCURACY OR AVAILABILITY OF THE NETWORK. WITHOUT LIMITING THE FOREGOING, NEITHER THE COMPANY NOR ANYONE ASSOCIATED WITH THE COMPANY REPRESENTS OR WARRANTS THAT THE NETWORK, ITS CONTENT OR ANY SERVICES OR ITEMS OBTAINED THROUGH THE NETWORK WILL BE ACCURATE, RELIABLE, ERROR-FREE OR UNINTERRUPTED, THAT DEFECTS WILL BE CORRECTED, THAT OUR SITE OR THE SERVER THAT MAKES IT AVAILABLE ARE FREE OF VIRUSES OR OTHER HARMFUL COMPONENTS OR THAT THE NETWORK OR ANY SERVICES OR ITEMS OBTAINED THROUGH THE NETWORK WILL OTHERWISE MEET YOUR NEEDS OR EXPECTATIONS.
+
+YOU HEREBY IRREVOCABLY WAIVE, RELEASE AND DISCHARGE ALL CLAIMS, WHETHER KNOWN OR UNKNOWN TO YOU, AGAINST US, OUR AFFILIATES AND THEIR RESPECTIVE SHAREHOLDERS, MEMBERS, DIRECTORS, OFFICERS, EMPLOYEES, AGENTS AND REPRESENTATIVES RELATED TO YOUR USE OF ANY WALLET SOFTWARE, ASSOCIATED LOSS OF FUNDS, TRANSACTION FAILURES, OR ANY OTHER DEFECTS THAT ARISE IN THE COURSE OF YOUR USE OF YOUR WALLET. THE COMPANY HEREBY DISCLAIMS ALL WARRANTIES OF ANY KIND, WHETHER EXPRESS OR IMPLIED, STATUTORY OR OTHERWISE, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF MERCHANTABILITY, NON-INFRINGEMENT AND FITNESS FOR PARTICULAR PURPOSE.
+
+THE FOREGOING DOES NOT AFFECT ANY WARRANTIES WHICH CANNOT BE EXCLUDED OR LIMITED UNDER APPLICABLE LAW.
+
+## Limitation on Liability
+
+IN NO EVENT WILL THE COMPANY, ITS AFFILIATES OR THEIR LICENSORS, SERVICE PROVIDERS, EMPLOYEES, AGENTS, OFFICERS OR DIRECTORS BE LIABLE FOR DAMAGES OF ANY KIND, UNDER ANY LEGAL THEORY, ARISING OUT OF OR IN CONNECTION WITH YOUR USE, OR INABILITY TO USE, THE NETWORK, ANY NETWORKS LINKED TO IT, ANY SMART CONTRACTS OR DISTRIBUTED APPLICATIONS EXISTING ON OR CONNECTING TO THE NETWORK, ANY LOSS OF FUNDS OR COLLATERAL, ANY CONTENT ON THE NETWORK OR SUCH OTHER NETWORKS OR ANY SERVICES OR ITEMS OBTAINED THROUGH THE NETWORK OR SUCH OTHER NETWORKS, INCLUDING ANY DIRECT, INDIRECT, SPECIAL, INCIDENTAL, CONSEQUENTIAL OR PUNITIVE DAMAGES, INCLUDING BUT NOT LIMITED TO, PERSONAL INJURY, PAIN AND SUFFERING, EMOTIONAL DISTRESS, LOSS OF REVENUE, LOSS OF PROFITS, LOSS OF BUSINESS OR ANTICIPATED SAVINGS, LOSS OF USE, LOSS OF GOODWILL, LOSS OF DATA, AND WHETHER CAUSED BY TORT (INCLUDING NEGLIGENCE), BREACH OF CONTRACT OR OTHERWISE, EVEN IF FORESEEABLE. UNDER NO CIRCUMSTANCES WILL WE BE RESPONSIBLE FOR ANY DAMAGES, LOSS OR INJURY RESULTING FROM HACKING, TAMPERING OR OTHER UNAUTHORIZED ACCESS OR USE OF THE NETWORK OR ITS CONTENTS.
+
+THE FOREGOING DOES NOT AFFECT ANY LIABILITY WHICH CANNOT BE EXCLUDED OR LIMITED UNDER APPLICABLE LAW.
+
+## Indemnification
+
+You agree to defend, indemnify and hold harmless the Company, its affiliates, licensors and service providers, and its and their respective officers, directors, employees, contractors, agents, licensors, suppliers, successors and assigns from and against any claims, liabilities, damages, judgments, awards, losses, costs, expenses, debts and fees (including reasonable attorneys' fees) arising out of or relating to: your use of or access to the Network; your violation of any third party right; the provision by you of any false or misleading information; your violation of any law, rule or regulation; your violation of these Terms of Use; your willful misconduct; or your use of the Network, including, but not limited to, your User Contributions, any use of the Network's content, services and products other than as expressly authorized in these Terms of Use or your use of any information obtained from the Network.
+
+## Release of Claims
+
+You acknowledge that the Network (including without limitation the smart contracts) and your use of the Network contain certain risks, including without limitation the following risks:  any smart contracts you interact with are entirely your own responsibility and your own liability, and we are not a party to the smart contracts; At any time, your access to your Digital Assets may be suspended or terminated or there may be a delay in your access or use of your Digital Assets which may result in the Digital Assets diminishing in value or you being unable to complete a smart contract; if your collateral declines such that your collateral is no longer sufficient to secure your position as a signer or depositor that a liquidation auction may not produce sufficient revenue to return your collateral, or other users may seize your collateral to close out your account; and the Network and related smart contracts may be suspended or terminated for any or no reason, which may limit your access to your Digital Assets. You assume all risk in connection with your access to and use of the Network and its smart contracts, and you waive and release us from any and all liability, claims, causes of action or damages arising from or in any way related to your use of the Network or the smart contracts.
+
+## Governing Law and Jurisdiction
+
+All matters relating to the Network and these Terms of Use and any dispute or claim arising therefrom or related thereto (in each case, including non-contractual disputes or claims), shall be governed by and construed in accordance with the internal laws of the Cayman Islands without giving effect to any choice or conflict of law provision or rule.
+
+Any legal suit, action or proceeding arising out of, or related to, these Terms of Use or the Network shall be instituted exclusively in the courts of the Cayman Islands. You waive any and all objections to the exercise of jurisdiction over you by such courts and to venue in such courts.
+
+## Arbitration
+
+At Company's sole discretion, it may require You to submit any disputes arising from the use of these Terms of Use or the Network, including disputes arising from or concerning their interpretation, violation, invalidity, non-performance, or termination, to final and binding arbitration under the Rules of Arbitration of the American Arbitration Association applying Cayman Island law.
+
+## Limitation on Time to File Claims
+
+ANY CAUSE OF ACTION OR CLAIM YOU MAY HAVE ARISING OUT OF OR RELATING TO THESE TERMS OF USE OR THE NETWORK MUST BE COMMENCED WITHIN ONE (1) YEAR AFTER THE CAUSE OF ACTION ACCRUES, OTHERWISE, SUCH CAUSE OF ACTION OR CLAIM IS PERMANENTLY BARRED.
+
+## Waiver and Severability
+
+No waiver of by the Company of any term or condition set forth in these Terms of Use shall be deemed a further or continuing waiver of such term or condition or a waiver of any other term or condition, and any failure of the Company to assert a right or provision under these Terms of Use shall not constitute a waiver of such right or provision.
+
+If any provision of these Terms of Use is held by a court or other tribunal of competent jurisdiction to be invalid, illegal or unenforceable for any reason, such provision shall be eliminated or limited to the minimum extent such that the remaining provisions of the Terms of Use will continue in full force and effect.
+
+## Entire Agreement
+
+The Terms of Use and our Privacy Policy constitute the sole and entire agreement between you and Keep SECZ with respect to the Network and supersede all prior and contemporaneous understandings, agreements, representations and warranties, both written and oral, with respect to the Network.
+
+## Your Comments and Concerns
+
+This Network is initially operated by Keep SEZC.
+
+All feedback, comments, requests for technical support and other communications relating to the Network should be directed to: [legal@keep.network](mailto:legal@keep.network).
+
+0142785.0724991 4828-0651-3078v3

--- a/src/templates/news-index.js
+++ b/src/templates/news-index.js
@@ -7,13 +7,14 @@ import Link from '../components/LocaleLink'
 
 const News = ({ data }) => {
   const { edges: newsItems } = data.allMarkdownRemark
+  const { frontmatter } = data.markdownRemark
   return (
     <App title="News">
       <div className="news">
         <div className="container">
           <div className="row justify-content-center no-gutters">
             <header className="page-header col-sm-12 col-md-12 col-lg-10">
-              <h1>News</h1>
+              <h1>{frontmatter.title}</h1>
               <Link to={`/news#mailing-list`}>Subscribe</Link>
             </header>
             <section className="col-sm-12 col-md-12 col-lg-10">
@@ -39,7 +40,12 @@ const News = ({ data }) => {
 News.propTypes = {
   data: PropTypes.shape({
     markdownRemark: PropTypes.shape({
-      locale: PropTypes.string,
+      fields: PropTypes.shape({
+        locale: PropTypes.string,
+      }),
+      frontmatter: PropTypes.shape({
+        title: PropTypes.string,
+      }),
     }),
     allMarkdownRemark: PropTypes.shape({
       edges: PropTypes.array,
@@ -56,6 +62,9 @@ export const query = graphql`
     markdownRemark(id: { eq: $id }) {
       fields {
         locale
+      }
+      frontmatter {
+        title
       }
     }
     allMarkdownRemark(


### PR DESCRIPTION
Generates markdown pages for each file listed in the "pages" collection if it doesn't already exist after Gatsby initialization.

We have to do this manually, since the "pages" collection is a file collection, and doesn't allow admin editors to freely add a page to the collection. (See the [docs](https://www.netlifycms.org/docs/collection-types/#file-collections)) Since they are copies, each locale md file will have English by default until they are edited.

Closes #123
Closes #106