### PR TITLE
Prevent legal pages from being translated

### DIFF
--- a/src/cms/config/index.js
+++ b/src/cms/config/index.js
@@ -40,12 +40,14 @@ function generateConfig() {
         ...collection,
         name: `${collection.name}-${lang}`,
         label: `${collection.label} (${lang})`,
-        files: collection.files.map((f) => ({
-          ...f,
-          name: `${f.name}-${lang}`,
-          label: `${f.name} (${lang})`,
-          file: f.file.replace(/(.*)\.(.*)$/, `$1.${lang}.$2`)
-        }))
+        files: collection.files
+          .filter(f => f.fields[0].default !== "legal-page")
+          .map((f) => ({
+            ...f,
+            name: `${f.name}-${lang}`,
+            label: `${f.name} (${lang})`,
+            file: f.file.replace(/(.*)\.(.*)$/, `$1.${lang}.$2`)
+          }))
       }))
     }
   })


### PR DESCRIPTION
Excludes legal pages from the cms config for non default locales. This prevents these pages from appearing in the admin view for non default locale page collections, but allows them to still exist
and be viewable in English on the site via locale link i.e. at /de/privacy-policy

Closes #126 