### PR TITLE
Localize announcement banner

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -11,21 +11,22 @@ const { defaultLocale, supportedLocales } = config.siteMetadata
 
 exports.onPreBootstrap = () => {
   const base = parseBaseConfig()
-  const pages =
-    base.collections.find(c => c.name === "pages").files.map(f => f.file)
+  const fileCollections =
+    base.collections.filter(c => c.name === "pages" || c.name === "header")
+  const files = fileCollections
+    .reduce((acc, curr) => acc.concat(curr.files.map(f => f.file )), [])
   const nonDefaultLocales = supportedLocales.filter(l => l !== defaultLocale)
 
-  // Generate markdown pages for each locale for each file listed in the "pages"
-  // collection if they do not already exist. The "pages" collection is a file
-  // collection, meaning that it does not allow admin editors to create new
+  // Generate markdown pages for each locale for each file if they do not
+  // already exist. File collections do not allow admin editors to create new
   // items in the collection. Each page must be explicitly added.
   // https://www.netlifycms.org/docs/collection-types/#file-collections
   // Since they are a copy, they will have English by default until edited.
   nonDefaultLocales.forEach(locale => {
-    pages.forEach(page => {
-      const localePage = page.replace(/(.*)\.(.*)$/, `$1.${locale}.$2`)
-      if (!fs.existsSync(localePage)) {
-        fs.copyFileSync(page, localePage)
+    files.forEach(file => {
+      const localeFile = file.replace(/(.*)\.(.*)$/, `$1.${locale}.$2`)
+      if (!fs.existsSync(localeFile)) {
+        fs.copyFileSync(file, localeFile)
       }
     })
   })

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -5,13 +5,12 @@ import SEO from './SEO.js'
 import '../css/app.scss'
 
 export default (props) => {
-  const { children, title, description } = props
-
+  const { children, title, description, locale } = props
   return (
     <div className="main">
       <Header />
       <SEO title={title} description={description} />
-      <Announcement />
+      <Announcement locale={locale} />
       <div className="app">
         { children }
       </div>

--- a/src/components/lib/Announcement.js
+++ b/src/components/lib/Announcement.js
@@ -37,7 +37,7 @@ export const query = graphql`
   }
 `
 
-const Announcement = ({ locale }) => (
+const Announcement = ({ locale = "en" }) => (
   <StaticQuery
     query={query}
     render={data => {

--- a/src/components/lib/Announcement.js
+++ b/src/components/lib/Announcement.js
@@ -1,8 +1,9 @@
-import React from 'react'
-import { graphql, StaticQuery } from 'gatsby'
+import React from "react"
+import { graphql, StaticQuery } from "gatsby"
+import PropTypes from "prop-types"
 
 
-const Announcement = ({ body }) => (
+const AnnouncementTemplate = ({ body }) => (
   <div className="announcement">
     <div className="container">
       <div className="row justify-content-center no-gutters">
@@ -14,6 +15,9 @@ const Announcement = ({ body }) => (
   </div>
 )
 
+AnnouncementTemplate.propTypes = {
+  body: PropTypes.string
+}
 
 // Query for announcement
 export const query = graphql`
@@ -24,21 +28,32 @@ export const query = graphql`
       edges {
         node {
           html
+          fields {
+            locale
+          }
         }
       }
     }
   }
 `
 
-export default () => (
+const Announcement = ({ locale }) => (
   <StaticQuery
     query={query}
     render={data => {
-      const body = data.allMarkdownRemark.edges[0].node.html
+      const match = data.allMarkdownRemark.edges
+        .find(e => e.node.fields.locale === locale)
+      const { html: body } = match.node
       if (!body) {
         return null
       }
-      return <Announcement body={body} />
+      return <AnnouncementTemplate body={body} />
     }}
   />
 )
+
+Announcement.propTypes = {
+  locale: PropTypes.string
+}
+
+export default Announcement

--- a/src/header/announcement.de.md
+++ b/src/header/announcement.de.md
@@ -1,0 +1,5 @@
+---
+template: announcement
+title: Stakedrop Announcement
+---
+Stake ETH to become a tBTC signer! Join for a live stakedrop event on June 8, 2020. <a href="https://www.crowdcast.io/e/keep-stakedrop---live" target="_blank" rel="noopener noreferrer">RSVP Here</a>

--- a/src/header/announcement.es.md
+++ b/src/header/announcement.es.md
@@ -1,0 +1,5 @@
+---
+template: announcement
+title: Stakedrop Announcement
+---
+Stake ETH to become a tBTC signer! Join for a live stakedrop event on June 8, 2020. <a href="https://www.crowdcast.io/e/keep-stakedrop---live" target="_blank" rel="noopener noreferrer">RSVP Here</a>

--- a/src/header/announcement.fr.md
+++ b/src/header/announcement.fr.md
@@ -1,0 +1,5 @@
+---
+template: announcement
+title: Stakedrop Announcement
+---
+Stake ETH to become a tBTC signer! Join for a live stakedrop event on June 8, 2020. <a href="https://www.crowdcast.io/e/keep-stakedrop---live" target="_blank" rel="noopener noreferrer">RSVP Here</a>

--- a/src/header/announcement.pl.md
+++ b/src/header/announcement.pl.md
@@ -1,0 +1,5 @@
+---
+template: announcement
+title: Stakedrop Announcement
+---
+Stake ETH to become a tBTC signer! Join for a live stakedrop event on June 8, 2020. <a href="https://www.crowdcast.io/e/keep-stakedrop---live" target="_blank" rel="noopener noreferrer">RSVP Here</a>

--- a/src/header/announcement.ru.md
+++ b/src/header/announcement.ru.md
@@ -1,0 +1,5 @@
+---
+template: announcement
+title: Stakedrop Announcement
+---
+Stake ETH to become a tBTC signer! Join for a live stakedrop event on June 8, 2020. <a href="https://www.crowdcast.io/e/keep-stakedrop---live" target="_blank" rel="noopener noreferrer">RSVP Here</a>

--- a/src/templates/about-page.js
+++ b/src/templates/about-page.js
@@ -30,11 +30,11 @@ export const AboutPageTemplate = ({ title, body, supporters }) => (
   </div>
 )
 
-const AboutPage = ({ data }) => {
+const AboutPage = ({ data, pageContext }) => {
   const { markdownRemark: post } = data
 
   return (
-    <App title={post.frontmatter.title}>
+    <App title={post.frontmatter.title} locale={pageContext.locale}>
       <AboutPageTemplate
         title={post.frontmatter.title}
         body={post.html}

--- a/src/templates/developers-page.js
+++ b/src/templates/developers-page.js
@@ -31,12 +31,12 @@ export const DevelopersPageTemplate = ({ title, body, resources }) => (
   </div>
 )
 
-const DevelopersPage = ({ data }) => {
+const DevelopersPage = ({ data, pageContext }) => {
   const { markdownRemark: post } = data
   const { edges: resources } = data.allMarkdownRemark
 
   return (
-    <App title={post.frontmatter.title}>
+    <App title={post.frontmatter.title} locale={pageContext.locale}>
       <DevelopersPageTemplate
         title={post.frontmatter.title}
         body={post.html}

--- a/src/templates/faq-page.js
+++ b/src/templates/faq-page.js
@@ -46,11 +46,11 @@ export const FaqPageTemplate = ({ title, questions }) => (
   </div>
 )
 
-const FaqPage = ({ data }) => {
+const FaqPage = ({ data, pageContext }) => {
   const { markdownRemark: post } = data
 
   return (
-    <App title={post.frontmatter.title}>
+    <App title={post.frontmatter.title} locale={pageContext.locale}>
       <FaqPageTemplate
         title={post.frontmatter.title}
         questions={post.frontmatter.questions} />

--- a/src/templates/home-page.js
+++ b/src/templates/home-page.js
@@ -113,12 +113,12 @@ export const HomePageTemplate = ({
   </div>
 }
 
-const HomePage = ({ data }) => {
+const HomePage = ({ data, pageContext }) => {
   const { markdownRemark: post } = data
   const { edges: newsItems } = data.allMarkdownRemark
 
   return (
-    <App>
+    <App locale={pageContext.locale}>
       <HomePageTemplate
         hero={post.frontmatter.hero}
         features={post.frontmatter.features}

--- a/src/templates/news-index.js
+++ b/src/templates/news-index.js
@@ -5,11 +5,11 @@ import PropTypes from 'prop-types'
 import { App } from './../components'
 import Link from '../components/LocaleLink'
 
-const News = ({ data }) => {
+const News = ({ data, pageContext }) => {
   const { edges: newsItems } = data.allMarkdownRemark
   const { frontmatter } = data.markdownRemark
   return (
-    <App title="News">
+    <App title="News" locale={pageContext.locale}>
       <div className="news">
         <div className="container">
           <div className="row justify-content-center no-gutters">

--- a/src/templates/news-item.js
+++ b/src/templates/news-item.js
@@ -15,11 +15,12 @@ export const NewsItemTemplate = ({ title, date, body }) => (
     body={body} />
 )
 
-const NewsItem = ({ data }) => {
+const NewsItem = ({ data, pageContext }) => {
   const { markdownRemark: post } = data
 
   return <App title={post.frontmatter.title}
-              description={post.frontmatter.description}>
+              description={post.frontmatter.description}
+              locale={pageContext.locale}>
     <NewsItemTemplate
       date={post.frontmatter.date}
       description={post.frontmatter.description}

--- a/src/templates/resource.js
+++ b/src/templates/resource.js
@@ -15,12 +15,12 @@ export const ResourceTemplate = ({ title, body, date }) => (
     date={date} />
 )
 
-const Resource = ({ data }) => {
+const Resource = ({ data, pageContext }) => {
   const { markdownRemark: post } = data
   const title = post.frontmatter.heading ?
     post.frontmatter.heading : post.frontmatter.title
 
-  return <App title={title}>
+  return <App title={title} locale={pageContext.locale}>
     <ResourceTemplate
       body={post.html}
       title={title}


### PR DESCRIPTION
Allows the announcement banner to be editable for each locale in the admin view. Ensures the correct translation is displayed in the `Announcement` component.

Since the `Announcement` component relies on a `StaticQuery` to fetch its data, we have to pass the locale in as a prop, as static queries don't accept variables. 

Closes #155 