### PR TITLE
Fix broken preview in admin

### DIFF
--- a/src/components/lib/LanguageDropdown.js
+++ b/src/components/lib/LanguageDropdown.js
@@ -7,7 +7,8 @@ import Dropdown from "./Dropdown"
 import { CustomLocaleLink as Link } from "../LocaleLink"
 
 const LanguageDropdownTemplate = ({ languages = [], selectedLanguage }) => {
-  const { location } = window
+  const location =
+    typeof window !== 'undefined' && window.location || { pathname: "" }
 
   // strip prefix build name from url if present
   const pathname =

--- a/src/components/lib/LanguageDropdown.js
+++ b/src/components/lib/LanguageDropdown.js
@@ -2,13 +2,12 @@ import React from "react"
 import { StaticQuery, graphql } from "gatsby"
 import PropTypes from "prop-types"
 import classNames from "classnames"
-import { useLocation } from "@reach/router"
 
 import Dropdown from "./Dropdown"
 import { CustomLocaleLink as Link } from "../LocaleLink"
 
 const LanguageDropdownTemplate = ({ languages = [], selectedLanguage }) => {
-  const location = useLocation()
+  const { location } = window
 
   // strip prefix build name from url if present
   const pathname =

--- a/src/components/lib/LanguageDropdown.js
+++ b/src/components/lib/LanguageDropdown.js
@@ -2,13 +2,17 @@ import React from "react"
 import { StaticQuery, graphql } from "gatsby"
 import PropTypes from "prop-types"
 import classNames from "classnames"
+import { useLocation } from "@reach/router"
 
 import Dropdown from "./Dropdown"
 import { CustomLocaleLink as Link } from "../LocaleLink"
 
 const LanguageDropdownTemplate = ({ languages = [], selectedLanguage }) => {
-  const location =
-    typeof window !== 'undefined' && window.location || { pathname: "" }
+  try {
+    var location = useLocation()
+  } catch (error) {
+    var location = window.location
+  }
 
   // strip prefix build name from url if present
   const pathname =


### PR DESCRIPTION
Replace `useLocation` hook with window.location

`useLocation` expects to be used when nested in a Router,
but this breaks the cms admin previews since the App is shown
standalone without any router