### PR TITLE
Add support for canonical URL link tags

### DIFF
--- a/src/cms/config/base-config.yml
+++ b/src/cms/config/base-config.yml
@@ -27,6 +27,7 @@ collections:
       - {label: "Path", name: "path", widget: "hidden"}
       - {label: "Title", name: "title", widget: "string"}
       - {label: "Description", name: "description", widget: "string"}
+      - {label: "Canonical URL", name: "canonicalUrl", widget: "string"}
       - {label: "Publish Date", name: "date", widget: "datetime"}
       - {label: "Body", name: "body", widget: "markdown"}
       - {label: "Tags", name: "tags", widget: "list", required: false}

--- a/src/pages/news/2024-04-15-a-tale-of-two-bugs.md
+++ b/src/pages/news/2024-04-15-a-tale-of-two-bugs.md
@@ -2,6 +2,7 @@
 template: news-item
 title: A tale of two bugs
 description: The FTX exploit attempted redemption of tBTC revealed two bugs.
+canonicalUrl: https://blog.threshold.network/a-tale-of-two-bugs/
 date: 2024-04-15T12:17:09.130Z
 ---
 As has been reported this week, an address associated with the FTX exploit has been moving funds through a number of cross-chain projects.

--- a/src/templates/news-item.js
+++ b/src/templates/news-item.js
@@ -1,34 +1,42 @@
-import React from 'react'
-import PropTypes from 'prop-types'
+import React from "react"
+import PropTypes from "prop-types"
 
-import { graphql } from 'gatsby'
+import { graphql } from "gatsby"
 
-import { App } from '../components'
-import { Article } from '../components/lib'
-
+import { App } from "../components"
+import { Article } from "../components/lib"
+import { Helmet } from "react-helmet"
 
 export const NewsItemTemplate = ({ title, date, body }) => (
-  <Article
-    className="news-item"
-    title={title}
-    date={date}
-    body={body}
-  />
+  <Article className="news-item" title={title} date={date} body={body} />
 )
 
 const NewsItem = ({ data, pageContext }) => {
   const { markdownRemark: post } = data
 
-  return <App title={post.frontmatter.title}
-              description={post.frontmatter.description}
-              locale={pageContext.locale}>
-    <NewsItemTemplate
-      date={post.frontmatter.date}
-      description={post.frontmatter.description}
-      body={post.html}
+  console.log(post.frontmatter, post.frontmatter.canonicalUrl)
+
+  return (
+    <App
       title={post.frontmatter.title}
-    />
-  </App>
+      description={post.frontmatter.description}
+      locale={pageContext.locale}
+    >
+      {post.frontmatter.canonicalUrl ? (
+        <Helmet>
+          <link rel="canonical" href={post.frontmatter.canonicalUrl} />
+        </Helmet>
+      ) : (
+        <></>
+      )}
+      <NewsItemTemplate
+        date={post.frontmatter.date}
+        description={post.frontmatter.description}
+        body={post.html}
+        title={post.frontmatter.title}
+      />
+    </App>
+  )
 }
 
 NewsItem.propTypes = {
@@ -48,6 +56,7 @@ export const pageQuery = graphql`
         date(formatString: "YYYY-MM-DD")
         title
         description
+        canonicalUrl
       }
     }
   }


### PR DESCRIPTION
News posts can now have a `canonicalUrl` frontmatter property that points to the URL that should be marked canonical. The A Tale of Two Bugs post implements this for the source Threshold blog post.